### PR TITLE
Collate Data Sources in Search Results

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -269,5 +269,6 @@ public class GetCombinedSearchResultsByNameUseCaseTests
 
         Assert.AreNotEqual(results[1].DataSource, results[0].DataSource);
         Assert.AreNotEqual(results[2].DataSource, results[0].DataSource);
+        Assert.AreNotEqual(results[2].DataSource, results[1].DataSource);
     }
 }

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
-using Bogus.DataSets;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -17,18 +16,16 @@ namespace SingleViewApi.Tests.V1.UseCase;
 [TestFixture]
 public class GetCombinedSearchResultsByNameUseCaseTests
 {
-    private Mock<IGetJigsawCustomersUseCase> _mockGetJigsawCustomersUseCase;
-    private Mock<IGetSearchResultsByNameUseCase> _mockGetSearchResultsByNameUseCase;
     private GetCombinedSearchResultsByNameUseCase _classUnderTest;
-    private Fixture _fixture;
+    private readonly Mock<IGetSearchResultsByNameUseCase> _mockGetSearchResultsByNameUseCase = new();
+    private readonly Mock<IGetJigsawCustomersUseCase> _mockGetJigsawCustomersUseCase = new();
+    private readonly Fixture _fixture = new();
 
     [SetUp]
     public void Setup()
     {
-        _mockGetJigsawCustomersUseCase = new Mock<IGetJigsawCustomersUseCase>();
-        _mockGetSearchResultsByNameUseCase = new Mock<IGetSearchResultsByNameUseCase>();
-        _classUnderTest = new GetCombinedSearchResultsByNameUseCase(_mockGetSearchResultsByNameUseCase.Object, _mockGetJigsawCustomersUseCase.Object);
-        _fixture = new Fixture();
+        _classUnderTest = new GetCombinedSearchResultsByNameUseCase(
+            _mockGetSearchResultsByNameUseCase.Object, _mockGetJigsawCustomersUseCase.Object);
     }
 
     [Test]
@@ -174,10 +171,6 @@ public class GetCombinedSearchResultsByNameUseCaseTests
         var results = _classUnderTest.Execute(firstName, lastName, userToken, redisId).Result;
 
         results.Should().BeEquivalentTo(expectedSearchResults);
-
-
-
-
     }
 
     [Test]
@@ -242,5 +235,39 @@ public class GetCombinedSearchResultsByNameUseCaseTests
         results[0].FirstName.Should().BeEquivalentTo(expectedSortedData[0].FirstName);
         results[1].FirstName.Should().BeEquivalentTo(expectedSortedData[1].FirstName);
         results[2].FirstName.Should().BeEquivalentTo(expectedSortedData[2].FirstName);
+    }
+
+    [Test]
+    public void CollatesDataSourcesInSearchResults()
+    {
+        var firstNameFixture = _fixture.Create<string>();
+        var lastNameFixture = _fixture.Create<string>();
+        var dataSourceListFixture = _fixture.CreateMany<DataSource>(3).ToList();
+        var searchResultsListFixture = _fixture.Build<SearchResult>()
+            .With(o => o.DataSource, dataSourceListFixture[0].Name).CreateMany(3).ToList();
+
+        searchResultsListFixture.Add(_fixture.Build<SearchResult>()
+            .With(o => o.FirstName, firstNameFixture)
+            .With(o => o.SurName, lastNameFixture)
+            .With(o => o.DataSource, dataSourceListFixture[2].Name)
+            .Create());
+
+        searchResultsListFixture.Add(_fixture.Build<SearchResult>()
+            .With(o => o.FirstName, firstNameFixture)
+            .With(o => o.SurName, lastNameFixture)
+            .With(o => o.DataSource, dataSourceListFixture[1].Name)
+            .Create());
+
+        searchResultsListFixture.Add(_fixture.Build<SearchResult>()
+            .With(o => o.FirstName, firstNameFixture)
+            .With(o => o.SurName, lastNameFixture)
+            .With(o => o.DataSource, dataSourceListFixture[0].Name)
+            .Create());
+
+        var results = _classUnderTest.SortResultsByRelevance(
+            firstNameFixture, lastNameFixture, searchResultsListFixture);
+
+        Assert.AreNotEqual(results[1].DataSource, results[0].DataSource);
+        Assert.AreNotEqual(results[2].DataSource, results[0].DataSource);
     }
 }

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -86,8 +85,9 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
     [LogCall]
     public List<SearchResult> SortResultsByRelevance(string firstName, string lastName, List<SearchResult> searchResults)
     {
-        return searchResults.OrderBy(x => x.FirstName == firstName ? 0 : 1).ThenBy(x => x.SurName == lastName ? 0 : 1).ToList();
+        return searchResults.OrderBy(result => result.SurName == lastName ? 0 : 1)
+            .ThenBy(result => result.FirstName == firstName ? 0 : 1)
+            .ThenBy(result => result.DataSource)
+            .ToList();
     }
-
-
 }

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -85,9 +86,36 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
     [LogCall]
     public List<SearchResult> SortResultsByRelevance(string firstName, string lastName, List<SearchResult> searchResults)
     {
-        return searchResults.OrderBy(result => result.SurName == lastName ? 0 : 1)
-            .ThenBy(result => result.FirstName == firstName ? 0 : 1)
-            .ThenBy(result => result.DataSource)
+        string firstNameFormatted = Normalise(firstName);
+        string lastNameFormatted = Normalise(lastName);
+        int firstNameFormattedLength = firstNameFormatted.Length;
+        int lastNameFormattedLength = lastNameFormatted.Length;
+        return searchResults
+
+                // Compare normalised substrings of the search results
+            .OrderBy(o => !String.Equals(Normalise(o.FirstName, firstNameFormattedLength), firstName, StringComparison.CurrentCultureIgnoreCase))
+            .ThenBy(o => !String.Equals(Normalise(o.SurName, lastNameFormattedLength), lastName, StringComparison.CurrentCultureIgnoreCase))
+            .ThenBy(o => !String.Equals(Normalise(o.FirstName, firstNameFormattedLength), firstName, StringComparison.CurrentCultureIgnoreCase) &&
+                        !String.Equals(Normalise(o.SurName, lastNameFormattedLength), lastName, StringComparison.CurrentCultureIgnoreCase))
+
+                // Then compare normalised whole matches
+            .ThenBy(o => !String.Equals(Normalise(o.FirstName), firstName, StringComparison.CurrentCultureIgnoreCase))
+            .ThenBy(o => !String.Equals(Normalise(o.SurName), lastName, StringComparison.CurrentCultureIgnoreCase))
+            .ThenBy(o => !String.Equals(Normalise(o.FirstName), firstName, StringComparison.CurrentCultureIgnoreCase) &&
+                         !String.Equals(Normalise(o.SurName), lastName, StringComparison.CurrentCultureIgnoreCase))
+
+                // Then compare non normalised whole matches
+            .ThenBy(o => !String.Equals(o.FirstName, firstName, StringComparison.CurrentCultureIgnoreCase))
+            .ThenBy(o => !String.Equals(o.SurName, lastName, StringComparison.CurrentCultureIgnoreCase))
+            .ThenBy(o => !String.Equals(o.FirstName, firstName, StringComparison.CurrentCultureIgnoreCase) &&
+                         !String.Equals(Normalise(o.SurName), lastName, StringComparison.CurrentCultureIgnoreCase))
             .ToList();
+    }
+
+    private string Normalise(string value, int len = 0)
+    {
+        value = value.Replace(" ", "");
+        if (len > 0 && len <= value.Length) value = value.Substring(0, len);
+        return value;
     }
 }

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -92,19 +92,19 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
         int lastNameFormattedLength = lastNameFormatted.Length;
         return searchResults
 
-                // Compare normalised substrings of the search results
+            // Compare normalised substrings of the search results
             .OrderBy(o => !String.Equals(Normalise(o.FirstName, firstNameFormattedLength), firstName, StringComparison.CurrentCultureIgnoreCase))
             .ThenBy(o => !String.Equals(Normalise(o.SurName, lastNameFormattedLength), lastName, StringComparison.CurrentCultureIgnoreCase))
             .ThenBy(o => !String.Equals(Normalise(o.FirstName, firstNameFormattedLength), firstName, StringComparison.CurrentCultureIgnoreCase) &&
                         !String.Equals(Normalise(o.SurName, lastNameFormattedLength), lastName, StringComparison.CurrentCultureIgnoreCase))
 
-                // Then compare normalised whole matches
+            // Then compare normalised whole matches
             .ThenBy(o => !String.Equals(Normalise(o.FirstName), firstName, StringComparison.CurrentCultureIgnoreCase))
             .ThenBy(o => !String.Equals(Normalise(o.SurName), lastName, StringComparison.CurrentCultureIgnoreCase))
             .ThenBy(o => !String.Equals(Normalise(o.FirstName), firstName, StringComparison.CurrentCultureIgnoreCase) &&
                          !String.Equals(Normalise(o.SurName), lastName, StringComparison.CurrentCultureIgnoreCase))
 
-                // Then compare non normalised whole matches
+            // Then compare non normalised whole matches
             .ThenBy(o => !String.Equals(o.FirstName, firstName, StringComparison.CurrentCultureIgnoreCase))
             .ThenBy(o => !String.Equals(o.SurName, lastName, StringComparison.CurrentCultureIgnoreCase))
             .ThenBy(o => !String.Equals(o.FirstName, firstName, StringComparison.CurrentCultureIgnoreCase) &&


### PR DESCRIPTION
## Link to Trello ticket

https://trello.com/c/f43c8CNR/179-sort-results-by-relevance-independent-of-system

## Describe this PR

### *What is the problem we're trying to solve*

Search results have subsequent data sources results appended to rather than collated with the initial result set.

### *What changes have we introduced*

Added `DataSource` to the `SortByRelevance` method and tested for collation of data sources in search results.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
