### PR TITLE
Add Academy Housing Benefits to Search

### DIFF
--- a/SingleViewApi.Tests/V1/Gateways/AcademyGatewayTests.cs
+++ b/SingleViewApi.Tests/V1/Gateways/AcademyGatewayTests.cs
@@ -85,6 +85,46 @@ public class AcademyGatewayTests
     }
 
     [Test]
+    public void GetCouncilTaxAccountByAccountRefMakesRequestToCouncilTax()
+    {
+        var accountRef = _fixture.Create<string>();
+        var userToken = _fixture.Create<string>();
+
+        _mockHttp.Expect($"{_baseUrl}/council-tax/{accountRef}")
+            .WithHeaders("Authorization", userToken);
+
+        _ = _classUnderTest.GetCouncilTaxAccountByAccountRef(accountRef, userToken);
+
+        _mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Test]
+    public async Task GetCouncilTaxAccountByAccountRefReturnsCouncilTaxRecordResponseObject()
+    {
+        var accountRef = _fixture.Create<string>();
+        var userToken = _fixture.Create<string>();
+        var stubbedResponse = _fixture.Create<CouncilTaxRecordResponseObject>();
+
+        _mockHttp.Expect($"{_baseUrl}/council-tax/{accountRef}")
+            .WithHeaders("Authorization", userToken)
+            .Respond("application/json",
+                JsonSerializer.Serialize<CouncilTaxRecordResponseObject>(stubbedResponse));
+
+        var result = await _classUnderTest.GetCouncilTaxAccountByAccountRef(accountRef, userToken);
+
+        _mockHttp.VerifyNoOutstandingExpectation();
+
+        Assert.AreEqual(stubbedResponse.Title, result.Title);
+        Assert.AreEqual(stubbedResponse.AccountBalance, result.AccountBalance);
+        Assert.AreEqual(stubbedResponse.AccountReference, result.AccountReference);
+        Assert.AreEqual(stubbedResponse.FirstName, result.FirstName);
+        AreEqualByJson(stubbedResponse.ForwardingAddress, result.ForwardingAddress);
+        Assert.AreEqual(stubbedResponse.LastName, result.LastName);
+        AreEqualByJson(stubbedResponse.PropertyAddress, result.PropertyAddress);
+        Assert.AreEqual(stubbedResponse.AccountCheckDigit, result.AccountCheckDigit);
+    }
+
+    [Test]
     public void GetHousingBenefitsAccountsByCustomerNameMakesRequestToHousingBenefitsSearch()
     {
         var firstName = _fixture.Create<string>();
@@ -141,47 +181,7 @@ public class AcademyGatewayTests
         Assert.AreEqual(stubbedResponse.Customers[0].FullAddress.Postcode, results.Customers[0].FullAddress.Postcode);
     }
 
-    [Test]
-    public void ARequestIsMadeToGetAccountByAccountRef()
-    {
-        var accountRef = _fixture.Create<string>();
-        var userToken = _fixture.Create<string>();
-
-        _mockHttp.Expect($"https://academy.api/council-tax/{accountRef}")
-            .WithHeaders("Authorization", userToken);
-
-        _ = _classUnderTest.GetCouncilTaxAccountByAccountRef(accountRef, userToken);
-
-        _mockHttp.VerifyNoOutstandingExpectation();
-    }
-
-    [Test]
-    public async Task CouncilTaxRecordResponseObjectWhenGotById()
-    {
-        var accountRef = _fixture.Create<string>();
-        var userToken = _fixture.Create<string>();
-        var stubbedResponse = _fixture.Create<CouncilTaxRecordResponseObject>();
-
-        _mockHttp.Expect($"https://academy.api/council-tax/{accountRef}")
-            .WithHeaders("Authorization", userToken)
-            .Respond("application/json",
-                JsonSerializer.Serialize<CouncilTaxRecordResponseObject>(stubbedResponse));
-
-        var result = await _classUnderTest.GetCouncilTaxAccountByAccountRef(accountRef, userToken);
-
-        _mockHttp.VerifyNoOutstandingExpectation();
-
-        Assert.AreEqual(stubbedResponse.Title, result.Title);
-        Assert.AreEqual(stubbedResponse.AccountBalance, result.AccountBalance);
-        Assert.AreEqual(stubbedResponse.AccountReference, result.AccountReference);
-        Assert.AreEqual(stubbedResponse.FirstName, result.FirstName);
-        AreEqualByJson(stubbedResponse.ForwardingAddress, result.ForwardingAddress);
-        Assert.AreEqual(stubbedResponse.LastName, result.LastName);
-        AreEqualByJson(stubbedResponse.PropertyAddress, result.PropertyAddress);
-        Assert.AreEqual(stubbedResponse.AccountCheckDigit, result.AccountCheckDigit);
-    }
-
-    public static void AreEqualByJson(object expected, object actual)
+    private static void AreEqualByJson(object expected, object actual)
     {
         var expectedJson = JSON.stringify(expected);
         var actualJson = JSON.stringify(actual);

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -23,6 +23,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests
     private Mock<IGetJigsawCustomersUseCase> _mockGetJigsawCustomersUseCase;
     private Mock<ISearchSingleViewUseCase> _mockSearchSingleViewUseCase;
     private Mock<IGetCouncilTaxAccountsByCustomerNameUseCase> _mockGetCouncilTaxAccountsByCustomerNameUseCase;
+    private Mock<IGetHousingBenefitsAccountsByCustomerNameUseCase> _mockGetHousingBenefitsAccountsByCustomerNameUseCase;
 
     [SetUp]
     public void Setup()
@@ -31,9 +32,14 @@ public class GetCombinedSearchResultsByNameUseCaseTests
         _mockGetJigsawCustomersUseCase = new Mock<IGetJigsawCustomersUseCase>();
         _mockSearchSingleViewUseCase = new Mock<ISearchSingleViewUseCase>();
         _mockGetCouncilTaxAccountsByCustomerNameUseCase = new Mock<IGetCouncilTaxAccountsByCustomerNameUseCase>();
+        _mockGetHousingBenefitsAccountsByCustomerNameUseCase = new Mock<IGetHousingBenefitsAccountsByCustomerNameUseCase>();
         _fixture = new Fixture();
         _classUnderTest = new GetCombinedSearchResultsByNameUseCase(
-            _mockGetSearchResultsByNameUseCase.Object, _mockGetJigsawCustomersUseCase.Object, _mockSearchSingleViewUseCase.Object, _mockGetCouncilTaxAccountsByCustomerNameUseCase.Object);
+            _mockGetSearchResultsByNameUseCase.Object,
+            _mockGetJigsawCustomersUseCase.Object,
+            _mockSearchSingleViewUseCase.Object,
+            _mockGetCouncilTaxAccountsByCustomerNameUseCase.Object,
+            _mockGetHousingBenefitsAccountsByCustomerNameUseCase.Object);
     }
 
     [Test]

--- a/SingleViewApi.Tests/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCaseTests.cs
@@ -33,7 +33,7 @@ public class GetHousingBenefitsAccountsByCustomerNameUseCaseTests : LogCallAspec
         var firstName = _fixture.Create<string>();
         var lastName = _fixture.Create<string>();
         var userToken = _fixture.Create<string>();
-        var stubDataSource = new DataSource() {Id = 4, Name = "Academy - Housing Benefits"};
+        var stubDataSource = new DataSource() { Id = 4, Name = "Academy - Housing Benefits" };
 
         _mockDataSourceGateway.Setup(x => x.GetEntityById(4)).Returns(stubDataSource);
         _mockAcademyGateway.Setup(x => x.GetHousingBenefitsAccountsByCustomerName(firstName, lastName, userToken))
@@ -50,7 +50,7 @@ public class GetHousingBenefitsAccountsByCustomerNameUseCaseTests : LogCallAspec
         var firstName = _fixture.Create<string>();
         var lastName = _fixture.Create<string>();
         var userToken = _fixture.Create<string>();
-        var stubDataSource = new DataSource() {Id = 4, Name = "Academy - Housing Benefits"};
+        var stubDataSource = new DataSource() { Id = 4, Name = "Academy - Housing Benefits" };
         var stubEntity = _fixture.Build<HousingBenefitsSearchResponseObject>()
             .Without(x => x.Error).Create();
 

--- a/SingleViewApi.Tests/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCaseTests.cs
@@ -1,0 +1,65 @@
+using AutoFixture;
+using FluentAssertions;
+using Hackney.Core.Testing.Shared;
+using Moq;
+using NUnit.Framework;
+using SingleViewApi.V1.Boundary;
+using SingleViewApi.V1.Boundary.Response;
+using SingleViewApi.V1.Domain;
+using SingleViewApi.V1.Gateways.Interfaces;
+using SingleViewApi.V1.UseCase;
+
+namespace SingleViewApi.Tests.V1.UseCase;
+
+public class GetHousingBenefitsAccountsByCustomerNameUseCaseTests : LogCallAspectFixture
+{
+    private Mock<IAcademyGateway> _mockAcademyGateway;
+    private Mock<IDataSourceGateway> _mockDataSourceGateway;
+    private GetHousingBenefitsAccountsByCustomerNameUseCase _classUnderTest;
+    private Fixture _fixture;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockAcademyGateway = new Mock<IAcademyGateway>();
+        _mockDataSourceGateway = new Mock<IDataSourceGateway>();
+        _classUnderTest = new GetHousingBenefitsAccountsByCustomerNameUseCase(_mockAcademyGateway.Object, _mockDataSourceGateway.Object);
+        _fixture = new Fixture();
+    }
+
+    [Test]
+    public void ExecuteResponseErrorHasNotFoundMessageIfGatewayReturnsNull()
+    {
+        var firstName = _fixture.Create<string>();
+        var lastName = _fixture.Create<string>();
+        var userToken = _fixture.Create<string>();
+        var stubDataSource = new DataSource() {Id = 4, Name = "Academy - Housing Benefits"};
+
+        _mockDataSourceGateway.Setup(x => x.GetEntityById(4)).Returns(stubDataSource);
+        _mockAcademyGateway.Setup(x => x.GetHousingBenefitsAccountsByCustomerName(firstName, lastName, userToken))
+            .ReturnsAsync((HousingBenefitsSearchResponseObject) null);
+
+        var result = _classUnderTest.Execute(firstName, lastName, userToken).Result;
+
+        Assert.That(result.SystemIds[0].Error, Is.EqualTo(SystemId.NotFoundMessage)); ;
+    }
+
+    [Test]
+    public void ExecuteSuccessfulResponseHasSearchResults()
+    {
+        var firstName = _fixture.Create<string>();
+        var lastName = _fixture.Create<string>();
+        var userToken = _fixture.Create<string>();
+        var stubDataSource = new DataSource() {Id = 4, Name = "Academy - Housing Benefits"};
+        var stubEntity = _fixture.Build<HousingBenefitsSearchResponseObject>()
+            .Without(x => x.Error).Create();
+
+        _mockDataSourceGateway.Setup(x => x.GetEntityById(4)).Returns(stubDataSource);
+        _mockAcademyGateway.Setup(x =>
+            x.GetHousingBenefitsAccountsByCustomerName(firstName, lastName, userToken)).ReturnsAsync(stubEntity);
+
+        var results = _classUnderTest.Execute(firstName, lastName, userToken).Result;
+
+        results.SearchResponse.SearchResults[^1].Should().Equals(stubEntity);
+    }
+}

--- a/SingleViewApi/Startup.cs
+++ b/SingleViewApi/Startup.cs
@@ -212,7 +212,8 @@ namespace SingleViewApi
                 var getJigsawCustomersUseCase = s.GetService<IGetJigsawCustomersUseCase>();
                 var searchSingleViewUseCase = s.GetService<ISearchSingleViewUseCase>();
                 var getCouncilTaxAccountsByCustomerNameUseCase = s.GetService<IGetCouncilTaxAccountsByCustomerNameUseCase>();
-                return new GetCombinedSearchResultsByNameUseCase(getSearchResultsByNameUseCase, getJigsawCustomersUseCase, searchSingleViewUseCase, getCouncilTaxAccountsByCustomerNameUseCase);
+                var getHousingBenefitsAccountsByCustomerNameUseCase = s.GetService<IGetHousingBenefitsAccountsByCustomerNameUseCase>();
+                return new GetCombinedSearchResultsByNameUseCase(getSearchResultsByNameUseCase, getJigsawCustomersUseCase, searchSingleViewUseCase, getCouncilTaxAccountsByCustomerNameUseCase, getHousingBenefitsAccountsByCustomerNameUseCase);
             });
 
             services.AddTransient<INotesGateway, NotesGateway>(s =>
@@ -277,6 +278,13 @@ namespace SingleViewApi
 
                 return new GetCouncilTaxAccountsByCustomerNameUseCase(academyGateway, dataSourceGateway);
 
+            });
+
+            services.AddTransient<IGetHousingBenefitsAccountsByCustomerNameUseCase, GetHousingBenefitsAccountsByCustomerNameUseCase>(s =>
+            {
+                var academyGateway = s.GetService<IAcademyGateway>();
+                var dataSourceGateway = s.GetService<IDataSourceGateway>();
+                return new GetHousingBenefitsAccountsByCustomerNameUseCase(academyGateway, dataSourceGateway);
             });
 
             services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();

--- a/SingleViewApi/V1/Boundary/Response/HousingBenefitsSearchResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/HousingBenefitsSearchResponseObject.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace SingleViewApi.V1.Boundary.Response;
+
+public class HousingBenefitsSearchResponseObject
+{
+    public List<HousingBenefitsSearchResponse> Customers { get; set; }
+
+#nullable enable
+    public string? Error { get; set; }
+
+#nullable disable
+}
+
+public class HousingBenefitsSearchResponse
+{
+    public string Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+#nullable enable
+    public DateTime? DateOfBirth { get; set; }
+    public string? NiNumber { get; set; }
+#nullable disable
+    public AcademyAddress FullAddress { get; set; }
+}

--- a/SingleViewApi/V1/Boundary/Response/HousingBenefitsSearchResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/HousingBenefitsSearchResponseObject.cs
@@ -22,5 +22,5 @@ public class HousingBenefitsSearchResponse
     public DateTime? DateOfBirth { get; set; }
     public string? NiNumber { get; set; }
 #nullable disable
-    public AcademyAddress FullAddress { get; set; }
+    public Address FullAddress { get; set; }
 }

--- a/SingleViewApi/V1/Controllers/CombinedSearchController.cs
+++ b/SingleViewApi/V1/Controllers/CombinedSearchController.cs
@@ -1,7 +1,5 @@
-using Hackney.Core.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using SingleViewApi.V1.Boundary.Response;
 using SingleViewApi.V1.UseCase.Interfaces;
 

--- a/SingleViewApi/V1/Gateways/AcademyGateway.cs
+++ b/SingleViewApi/V1/Gateways/AcademyGateway.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -40,6 +39,30 @@ public class AcademyGateway : IAcademyGateway
 
             results = JsonConvert.DeserializeObject<CouncilTaxSearchResponseObject>(jsonBody);
 
+        }
+
+        return results;
+    }
+
+    [LogCall]
+    public async Task<HousingBenefitsSearchResponseObject> GetHousingBenefitsAccountsByCustomerName(string firstName, string lastName, string userToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"{_baseUrl}/benefits/search?firstName={firstName}&lastName={lastName}");
+
+        request.Headers.Add("Authorization", userToken);
+        var response = await _httpClient.SendAsync(request);
+
+#nullable enable
+        HousingBenefitsSearchResponseObject? results = null;
+#nullable disable
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+
+            var jsonBody = response.Content.ReadAsStringAsync().Result;
+
+            results = JsonConvert.DeserializeObject<HousingBenefitsSearchResponseObject>(jsonBody);
         }
 
         return results;

--- a/SingleViewApi/V1/Gateways/AcademyGateway.cs
+++ b/SingleViewApi/V1/Gateways/AcademyGateway.cs
@@ -49,7 +49,6 @@ public class AcademyGateway : IAcademyGateway
     {
         var request = new HttpRequestMessage(HttpMethod.Get,
             $"{_baseUrl}/benefits/search?firstName={firstName}&lastName={lastName}");
-
         request.Headers.Add("Authorization", userToken);
         var response = await _httpClient.SendAsync(request);
 
@@ -59,9 +58,7 @@ public class AcademyGateway : IAcademyGateway
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
-
             var jsonBody = response.Content.ReadAsStringAsync().Result;
-
             results = JsonConvert.DeserializeObject<HousingBenefitsSearchResponseObject>(jsonBody);
         }
 

--- a/SingleViewApi/V1/Gateways/Interfaces/IAcademyGateway.cs
+++ b/SingleViewApi/V1/Gateways/Interfaces/IAcademyGateway.cs
@@ -6,4 +6,6 @@ namespace SingleViewApi.V1.Gateways.Interfaces;
 public interface IAcademyGateway
 {
     Task<CouncilTaxSearchResponseObject> GetCouncilTaxAccountsByCustomerName(string firstName, string lastName, string userToken);
+
+    Task<HousingBenefitsSearchResponseObject> GetHousingBenefitsAccountsByCustomerName(string firstName, string lastName, string userToken);
 }

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -18,13 +18,15 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
     private readonly IGetJigsawCustomersUseCase _getJigsawCustomersUseCase;
     private readonly ISearchSingleViewUseCase _searchSingleViewUseCase;
     private readonly IGetCouncilTaxAccountsByCustomerNameUseCase _getCouncilTaxAccountsByCustomerNameUseCase;
+    private readonly IGetHousingBenefitsAccountsByCustomerNameUseCase _getHousingBenefitsAccountsByCustomerNameUseCase;
 
-    public GetCombinedSearchResultsByNameUseCase(IGetSearchResultsByNameUseCase getSearchResultsByNameUseCase, IGetJigsawCustomersUseCase getJigsawCustomersUseCase, ISearchSingleViewUseCase searchSingleViewUseCase, IGetCouncilTaxAccountsByCustomerNameUseCase getCouncilTaxAccountsByCustomerNameUseCase)
+    public GetCombinedSearchResultsByNameUseCase(IGetSearchResultsByNameUseCase getSearchResultsByNameUseCase, IGetJigsawCustomersUseCase getJigsawCustomersUseCase, ISearchSingleViewUseCase searchSingleViewUseCase, IGetCouncilTaxAccountsByCustomerNameUseCase getCouncilTaxAccountsByCustomerNameUseCase, IGetHousingBenefitsAccountsByCustomerNameUseCase getHousingBenefitsAccountsByCustomerNameUseCase)
     {
         _getSearchResultsByNameUseCase = getSearchResultsByNameUseCase;
         _searchSingleViewUseCase = searchSingleViewUseCase;
         _getJigsawCustomersUseCase = getJigsawCustomersUseCase;
         _getCouncilTaxAccountsByCustomerNameUseCase = getCouncilTaxAccountsByCustomerNameUseCase;
+        _getHousingBenefitsAccountsByCustomerNameUseCase = getHousingBenefitsAccountsByCustomerNameUseCase;
     }
     [LogCall]
     public async Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken,
@@ -34,6 +36,8 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
         var housingResults = await _getSearchResultsByNameUseCase.Execute(firstName, lastName, userToken);
         var councilTaxResults =
             await _getCouncilTaxAccountsByCustomerNameUseCase.Execute(firstName, lastName, userToken);
+        var housingBenefitsResults =
+            await _getHousingBenefitsAccountsByCustomerNameUseCase.Execute(firstName, lastName, userToken);
 
         Console.WriteLine($"In combined use case - councilResults are {JSON.stringify(councilTaxResults)}");
 
@@ -50,7 +54,8 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
                 singleViewResults: singleViewResults?.SearchResponse?.SearchResults,
                 housingResults: housingResults?.SearchResponse?.SearchResults,
                 jigsawResults: jigsawResults?.SearchResponse?.SearchResults,
-                councilTaxResults: councilTaxResults?.SearchResponse?.SearchResults);
+                councilTaxResults: councilTaxResults?.SearchResponse?.SearchResults,
+                housingBenefitsResults: housingBenefitsResults?.SearchResponse?.SearchResults);
 
             total += jigsawResults?.SearchResponse?.Total ?? 0;
 
@@ -61,7 +66,8 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
             concatenatedResults = ConcatenateResults(
                 singleViewResults: singleViewResults?.SearchResponse?.SearchResults,
                 housingResults: housingResults?.SearchResponse?.SearchResults,
-                councilTaxResults: councilTaxResults?.SearchResponse?.SearchResults);
+                councilTaxResults: councilTaxResults?.SearchResponse?.SearchResults,
+                housingBenefitsResults: housingBenefitsResults?.SearchResponse?.SearchResults);
         }
 
         var sortedResults = SortResultsByRelevance(firstName, lastName, concatenatedResults);
@@ -85,9 +91,9 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
     }
 
     [LogCall]
-    private List<SearchResult> ConcatenateResults([Optional] List<SearchResult> singleViewResults, [Optional] List<SearchResult> housingResults, [Optional] List<SearchResult> jigsawResults, [Optional] List<SearchResult> councilTaxResults)
+    private List<SearchResult> ConcatenateResults([Optional] List<SearchResult> singleViewResults, [Optional] List<SearchResult> housingResults, [Optional] List<SearchResult> jigsawResults, [Optional] List<SearchResult> councilTaxResults, [Optional] List<SearchResult> housingBenefitsResults)
     {
-        return NeverNull(singleViewResults).Concat(NeverNull(housingResults)).Concat(NeverNull(jigsawResults)).Concat(NeverNull(councilTaxResults))
+        return NeverNull(singleViewResults).Concat(NeverNull(housingResults)).Concat(NeverNull(jigsawResults)).Concat(NeverNull(councilTaxResults)).Concat(NeverNull(housingBenefitsResults))
             .ToList();
     }
 

--- a/SingleViewApi/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCase.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hackney.Core.Logging;
+using SingleViewApi.V1.Boundary;
+using SingleViewApi.V1.Boundary.Response;
+using SingleViewApi.V1.Gateways.Interfaces;
+using SingleViewApi.V1.UseCase.Interfaces;
+
+namespace SingleViewApi.V1.UseCase;
+
+public class GetHousingBenefitsAccountsByCustomerNameUseCase : IGetHousingBenefitsAccountsByCustomerNameUseCase
+{
+    private readonly IAcademyGateway _academyGateway;
+    private readonly IDataSourceGateway _dataSourceGateway;
+
+    public GetHousingBenefitsAccountsByCustomerNameUseCase(IAcademyGateway academyGateway, IDataSourceGateway dataSourceGateway)
+    {
+        _academyGateway = academyGateway;
+        _dataSourceGateway = dataSourceGateway;
+    }
+
+    [LogCall]
+    public async Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken)
+    {
+        var dataSource = _dataSourceGateway.GetEntityById(4);
+        var academyApiId = new SystemId() { SystemName = dataSource.Name, Id = $"{firstName}+{lastName}" };
+        var response = new SearchResponseObject() { SystemIds = new List<SystemId>() { academyApiId } };
+        var accounts = await _academyGateway.GetHousingBenefitsAccountsByCustomerName(firstName, lastName, userToken);
+
+        if (accounts == null || accounts.Customers.Count == 0)
+        {
+            academyApiId.Error = SystemId.NotFoundMessage;
+            return response;
+        }
+
+        if (accounts.Error != null)
+        {
+            Console.WriteLine($"Error from Academy Housing Benefits Use Case: {accounts.Error}");
+            academyApiId.Error = accounts.Error;
+            return response;
+        }
+
+        var searchResults = new List<SearchResult>();
+
+        foreach (var account in accounts.Customers)
+        {
+            var result = new SearchResult()
+            {
+                Id = account.Id,
+                DataSource = dataSource.Name,
+                FirstName = account.FirstName,
+                SurName = account.LastName,
+                DateOfBirth = account?.DateOfBirth,
+                NiNumber = account?.NiNumber,
+                KnownAddresses = new List<KnownAddress>()
+                {
+                    new KnownAddress() { CurrentAddress = true, FullAddress = AddressToString(account.FullAddress)  }
+                }
+            };
+            searchResults.Add(result);
+        }
+        response.SearchResponse = new SearchResponse()
+        {
+            SearchResults = searchResults,
+            Total = searchResults.Count
+        };
+        return response;
+    }
+
+    public string AddressToString(AcademyAddress address)
+    {
+        return $"{address?.Line1} {address?.Line2} {address?.Line3} {address?.Line4} {address?.Postcode}";
+    }
+}

--- a/SingleViewApi/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCase.cs
@@ -68,7 +68,7 @@ public class GetHousingBenefitsAccountsByCustomerNameUseCase : IGetHousingBenefi
         return response;
     }
 
-    public string AddressToString(AcademyAddress address)
+    public string AddressToString(Address address)
     {
         return $"{address?.Line1} {address?.Line2} {address?.Line3} {address?.Line4} {address?.Postcode}";
     }

--- a/SingleViewApi/V1/UseCase/Interfaces/IGetHousingBenefitsAccountsByCustomerNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/Interfaces/IGetHousingBenefitsAccountsByCustomerNameUseCase.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using SingleViewApi.V1.Boundary.Response;
+
+namespace SingleViewApi.V1.UseCase.Interfaces;
+
+public interface IGetHousingBenefitsAccountsByCustomerNameUseCase
+{
+    Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken);
+}


### PR DESCRIPTION
## Link to Trello ticket

https://trello.com/c/sz12rSq0/194-sv-connect-to-academy-housing-benefits-search-endpoint

## Describe this PR

### *What is the problem we're trying to solve*

We need to combine search results from [Academy API](https://github.com/LBHackney-IT/academy-api)'s `/api/v1/benefits/search` endpoint into Single View API's search.

### *What changes have we introduced*

Refactored Academy gateway to include the Housing Benefits search endpoint, added new use case to get Housing Benefits accounts and included this in the combined search use case.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

None.
