### PR TITLE
show personTypes as string equivalent

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
@@ -104,7 +104,7 @@ namespace SingleViewApi.Tests.V1.UseCase
                 PlaceOfBirth = null,
                 PreferredFirstName = mockFirstName,
                 PreferredMiddleName = null,
-                PersonTypes = new List<PersonType> { Hackney.Shared.Person.Domain.PersonType.Tenant }
+                PersonTypes = new List<string> { Hackney.Shared.Person.Domain.PersonType.Tenant.ToDescription() }
             };
 
             _mockGetPersonApiByIdUseCase.Setup(x => x.Execute(mockPersonApi, userToken)).ReturnsAsync(new CustomerResponseObject()
@@ -276,7 +276,7 @@ namespace SingleViewApi.Tests.V1.UseCase
                 PlaceOfBirth = null,
                 PreferredFirstName = mockFirstName,
                 PreferredMiddleName = null,
-                PersonTypes = new List<PersonType> { Hackney.Shared.Person.Domain.PersonType.Tenant }
+                PersonTypes = new List<string> { Hackney.Shared.Person.Domain.PersonType.Tenant.ToDescription() }
             };
 
             _mockGetPersonApiByIdUseCase.Setup(x => x.Execute(mockPersonApi, userToken)).ReturnsAsync(new CustomerResponseObject()

--- a/SingleViewApi/V1/Boundary/Response/CustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/CustomerResponseObject.cs
@@ -39,7 +39,7 @@ namespace SingleViewApi.V1.Boundary.Response
 
         public List<KnownAddress> KnownAddresses { get; set; }
 
-        public List<PersonType> PersonTypes { get; set; }
+        public List<string> PersonTypes { get; set; }
 
 #nullable enable
         public DateTime? DateOfBirth { get; set; }

--- a/SingleViewApi/V1/Boundary/Response/MergedCustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/MergedCustomerResponseObject.cs
@@ -35,7 +35,7 @@ namespace SingleViewApi.V1.Boundary.Response
         public List<KnownAddress> KnownAddresses { get; set; }
         public List<CutomerContactDetails> ContactDetails { get; set; }
 
-        public List<PersonType> PersonTypes { get; set; }
+        public List<String> PersonTypes { get; set; }
 #nullable enable
 
         public CouncilTaxAccountInfo? CouncilTaxAccount { get; set; }

--- a/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
@@ -83,7 +83,7 @@ namespace SingleViewApi.V1.UseCase
             var allSystemIds = new List<SystemId>();
             var allKnownAddresses = new List<KnownAddress>();
             var allContactDetails = new List<CutomerContactDetails>();
-            var allPersonType = new List<PersonType>();
+            var allPersonType = new List<string>();
             var mergedCustomer = new MergedCustomer()
             {
                 Id = customer.Id.ToString(),

--- a/SingleViewApi/V1/UseCase/GetPersonAPIByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetPersonAPIByIdUseCase.cs
@@ -9,6 +9,7 @@ using Hackney.Core.Logging;
 using Hackney.Shared.ContactDetail.Domain;
 using Hackney.Shared.Person;
 using Microsoft.OpenApi.Extensions;
+using ServiceStack;
 using SingleViewApi.V1.Boundary;
 using SingleViewApi.V1.Domain;
 using SingleViewApi.V1.Gateways.Interfaces;
@@ -62,6 +63,14 @@ namespace SingleViewApi.V1.UseCase
             }
             else
             {
+
+                var personTypes = new List<string>();
+
+                foreach (var personType in person.PersonTypes)
+                {
+                    personTypes.Add(personType.ToDescription());
+                }
+
                 response.Customer = new Customer()
                 {
                     Id = person.Id.ToString(),
@@ -77,7 +86,7 @@ namespace SingleViewApi.V1.UseCase
                     DateOfBirth = person.DateOfBirth,
                     DateOfDeath = person.DateOfDeath,
                     IsAMinor = person.IsAMinor,
-                    PersonTypes = person.PersonTypes?.ToList(),
+                    PersonTypes = personTypes,
                     ContactDetails = contactDetails,
                     EqualityInformation = equalityInformation,
                     CautionaryAlerts = cautionaryAlerts,


### PR DESCRIPTION
https://trello.com/c/RJqw6hng/215-tenure-types-displaying-incorrectly

Small bug fix. Show personTypes as strings rather than enum 