### PR TITLE
New DataSourceName attr on KnownAddress + Tests

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetJigsawCustomerByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetJigsawCustomerByIdUseCaseTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SingleViewApi.V1.Boundary;
+using SingleViewApi.V1.Boundary.Response;
+using SingleViewApi.V1.Domain;
+using SingleViewApi.V1.Gateways.Interfaces;
+using SingleViewApi.V1.UseCase;
+using SingleViewApi.V1.UseCase.Interfaces;
+
+namespace SingleViewApi.Tests.V1.UseCase;
+
+[TestFixture]
+public class GetJigsawCustomerByIdUseCaseTest
+{
+    private Mock<IJigsawGateway> _mockJigsawGateway;
+    private Mock<IGetJigsawAuthTokenUseCase> _mockGetJigsawAuthTokenUseCase;
+    private GetJigsawCustomerByIdUseCase _classUnderTest;
+    private Fixture _fixture;
+    private Mock<IDataSourceGateway> _mockDataSourceGateway;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockJigsawGateway = new Mock<IJigsawGateway>();
+        _mockGetJigsawAuthTokenUseCase = new Mock<IGetJigsawAuthTokenUseCase>();
+        _mockDataSourceGateway = new Mock<IDataSourceGateway>();
+        _classUnderTest = new GetJigsawCustomerByIdUseCase(_mockJigsawGateway.Object, _mockGetJigsawAuthTokenUseCase.Object, _mockDataSourceGateway.Object);
+        _fixture = new Fixture();
+    }
+
+    [Test]
+    public void UseCaseReturnsNullIfAuthFails()
+    {
+        string redisId = _fixture.Create<string>();
+        const string hackneyToken = "test-token";
+        string stubbedCustomerId = _fixture.Create<string>();
+
+        _mockGetJigsawAuthTokenUseCase.Setup(x => x.Execute(redisId, hackneyToken)).ReturnsAsync(new AuthGatewayResponse() { Token = null, ExceptionMessage = "No token present" }); ;
+
+        var result = _classUnderTest.Execute(stubbedCustomerId, redisId, hackneyToken).Result;
+
+        Assert.That(result, Is.EqualTo(null));
+
+    }
+
+    [Test]
+    public void ReturnsCustomerResponseObject()
+    {
+        var redisId = _fixture.Create<string>();
+        var jigsawToken = _fixture.Create<string>();
+        const string hackneyToken = "test-token";
+        var stubbedEntity = _fixture.Create<JigsawCustomerResponseObject>();
+        var stubbedDataSource = _fixture.Create<DataSource>();
+        var stubbedCustomerId = _fixture.Create<string>();
+
+        _mockGetJigsawAuthTokenUseCase.Setup(x => x.Execute(redisId, hackneyToken)).ReturnsAsync(new AuthGatewayResponse() { Token = jigsawToken, ExceptionMessage = null });
+        _mockDataSourceGateway.Setup(x => x.GetEntityById(2)).Returns(stubbedDataSource);
+
+        _mockJigsawGateway.Setup(x => x.GetCustomerById(stubbedCustomerId, jigsawToken)).ReturnsAsync(stubbedEntity);
+
+        var results = _classUnderTest.Execute(stubbedCustomerId, redisId, hackneyToken).Result;
+
+        results.SystemIds[^1].SystemName.Should().BeEquivalentTo(stubbedDataSource.Name);
+        results.SystemIds[^1].Id.Should().BeEquivalentTo(stubbedEntity.Id);
+        results.Customer.FirstName.Should().BeEquivalentTo(stubbedEntity.PersonInfo.FirstName);
+        results.Customer.Surname.Should().BeEquivalentTo(stubbedEntity.PersonInfo.LastName);
+        results.Customer.DateOfBirth.Should().Be(stubbedEntity.PersonInfo.DateOfBirth);
+        results.Customer.DataSource.Should().Be(stubbedDataSource);
+        results.Customer.NiNo.Should().BeEquivalentTo(stubbedEntity.PersonInfo.NationalInsuranceNumber);
+        results.Customer.NhsNumber.Should().BeEquivalentTo(stubbedEntity.PersonInfo.NhsNumber);
+        results.Customer.KnownAddresses[0].FullAddress.Should().BeEquivalentTo(stubbedEntity.PersonInfo.AddressString);
+        results.Customer.KnownAddresses[0].CurrentAddress.Should().Be(true);
+        results.Customer.KnownAddresses[0].DataSourceName.Should().BeEquivalentTo(stubbedDataSource.Name);
+    }
+}

--- a/SingleViewApi.Tests/V1/UseCase/GetPersonApiByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetPersonApiByIdUseCaseTests.cs
@@ -82,6 +82,7 @@ namespace SingleViewApi.Tests.V1.UseCase
             result.Customer.KnownAddresses[0].StartDate.Should().Be(stubbedPerson.Tenures.ToList()[0].StartDate);
             result.Customer.KnownAddresses[0].FullAddress.Should().Be(stubbedPerson.Tenures.ToList()[0].AssetFullAddress);
             result.Customer.KnownAddresses[0].CurrentAddress.Should().Be(stubbedPerson.Tenures.ToList()[0].IsActive);
+            result.Customer.KnownAddresses[0].DataSourceName.Should().BeEquivalentTo(stubbedDataSource.Name);
             result.Customer.ContactDetails.Should().BeEquivalentTo(stubbedContactDetails);
             result.Customer.EqualityInformation.Should().BeEquivalentTo(stubbedEqualityInfo);
             //result.Customer.CautionaryAlerts.Should().BeEquivalentTo(stubbedCautionaryAlerts);

--- a/SingleViewApi/V1/Boundary/KnownAddress.cs
+++ b/SingleViewApi/V1/Boundary/KnownAddress.cs
@@ -11,5 +11,6 @@ namespace SingleViewApi.V1.Boundary
         public string? StartDate { get; set; }
         public string? EndDate { get; set; }
 #nullable disable
+        public string DataSourceName { get; set; }
     }
 }

--- a/SingleViewApi/V1/UseCase/GetJigsawCustomerByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetJigsawCustomerByIdUseCase.cs
@@ -39,18 +39,18 @@ public class GetJigsawCustomerByIdUseCase : IGetJigsawCustomerByIdUseCase
             return null;
         }
 
-        var customer = await _jigsawGateway.GetCustomerById(customerId, jigsawAuthResponse.Token);
+        var jigsawResponse = await _jigsawGateway.GetCustomerById(customerId, jigsawAuthResponse.Token);
 
 
         var dataSource = _dataSourceGateway.GetEntityById(2);
 
-        var jigsawId = new SystemId() { SystemName = dataSource?.Name, Id = customer?.Id };
+        var jigsawId = new SystemId() { SystemName = dataSource?.Name, Id = jigsawResponse?.Id };
 
         var systemIdList = new List<SystemId>() { jigsawId };
 
         var response = new CustomerResponseObject() { SystemIds = systemIdList };
 
-        if (customer == null)
+        if (jigsawResponse == null)
         {
             jigsawId.Error = "Not found";
         }
@@ -58,20 +58,21 @@ public class GetJigsawCustomerByIdUseCase : IGetJigsawCustomerByIdUseCase
         {
             response.Customer = new Customer()
             {
-                Id = customer.Id,
-                FirstName = customer.PersonInfo.FirstName,
-                Surname = customer.PersonInfo.LastName,
-                DateOfBirth = customer.PersonInfo.DateOfBirth,
+                Id = jigsawResponse.Id,
+                FirstName = jigsawResponse.PersonInfo.FirstName,
+                Surname = jigsawResponse.PersonInfo.LastName,
+                DateOfBirth = jigsawResponse.PersonInfo.DateOfBirth,
                 DataSource = dataSource,
-                NiNo = customer.PersonInfo.NationalInsuranceNumber,
-                NhsNumber = customer.PersonInfo.NhsNumber,
+                NiNo = jigsawResponse.PersonInfo.NationalInsuranceNumber,
+                NhsNumber = jigsawResponse.PersonInfo.NhsNumber,
                 KnownAddresses = new List<KnownAddress>()
                 {
                     new KnownAddress()
                     {
 
-                        FullAddress = customer.PersonInfo.AddressString,
-                        CurrentAddress = true
+                        FullAddress = jigsawResponse.PersonInfo.AddressString,
+                        CurrentAddress = true,
+                        DataSourceName = dataSource.Name
                     }
                 }
             };

--- a/SingleViewApi/V1/UseCase/GetPersonAPIByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetPersonAPIByIdUseCase.cs
@@ -92,12 +92,12 @@ namespace SingleViewApi.V1.UseCase
                     //CautionaryAlerts = cautionaryAlerts,
                     KnownAddresses = new List<KnownAddress>(person.Tenures.Select(t => new KnownAddress()
                     {
-
                         Id = t.Id,
                         CurrentAddress = t.IsActive,
                         StartDate = t.StartDate,
                         EndDate = t.EndDate,
-                        FullAddress = t.AssetFullAddress
+                        FullAddress = t.AssetFullAddress,
+                        DataSourceName = dataSource.Name
                     }))
                 };
             }


### PR DESCRIPTION
[Trello Card](https://trello.com/c/5Z5kwbMk/221-display-where-addresses-are-coming-from)

#### Summary / Context:

as a user I would like to see where addresses are coming from,
so that I could correct information at the source where appropriate

Currently the API doesn't return the data source of each address, so we cannot yet update the frontend to display that data on the frontend to be viewed by users.

Added `DataSourceName` as a mandatory attribute to the `SingleViewApi.V1.Boundary.KnownAddress` class
Updated all relevant UseCases to include the new attribute

#### Other changes:
Renamed `customer` to `JigsawResponse` in `GetJigsawCustomerByIdUseCase.cs` for clarity

#### _Checklist_

- [ x ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ x ] Added tests to cover all new production code
- [ x ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ x ] Checked all code for possible refactoring
- [ x ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Need to update the frontend to display the new data source names returned from the API
