### PR TITLE
Update MergedCustomer To Display Cautionary Alerts

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
@@ -92,6 +92,7 @@ namespace SingleViewApi.Tests.V1.UseCase
 
             var fakeContactDetails = _fixture.Create<ContactDetails>();
             var fakeKnownAddresses = _fixture.CreateMany<KnownAddress>().ToList();
+            var fakeCautionaryAlerts = _fixture.CreateMany<CautionaryAlert>().ToList();
 
             var peronsApiCustomer = new Customer()
             {
@@ -112,7 +113,8 @@ namespace SingleViewApi.Tests.V1.UseCase
                 PlaceOfBirth = null,
                 PreferredFirstName = mockFirstName,
                 PreferredMiddleName = null,
-                PersonTypes = new List<string> { Hackney.Shared.Person.Domain.PersonType.Tenant.ToDescription() }
+                PersonTypes = new List<string> { Hackney.Shared.Person.Domain.PersonType.Tenant.ToDescription() },
+                CautionaryAlerts = fakeCautionaryAlerts
             };
 
             _mockGetPersonApiByIdUseCase.Setup(x => x.Execute(mockPersonApi, userToken)).ReturnsAsync(new CustomerResponseObject()
@@ -130,6 +132,7 @@ namespace SingleViewApi.Tests.V1.UseCase
 
             var fakeJigsawContactDetails = _fixture.Create<ContactDetails>();
             var fakeJigsawKnownAddresses = _fixture.CreateMany<KnownAddress>().ToList();
+            var fakeJigsawCautionaryAlerts = _fixture.CreateMany<CautionaryAlert>().ToList();
 
             var jigsawApiCustomer = new Customer()
             {
@@ -150,7 +153,8 @@ namespace SingleViewApi.Tests.V1.UseCase
                 PlaceOfBirth = null,
                 PreferredFirstName = null,
                 PreferredMiddleName = null,
-                PersonTypes = null
+                PersonTypes = null,
+                CautionaryAlerts = fakeCautionaryAlerts
             };
 
             _mockGetJigsawCustomerByIdUseCase.Setup(x => x.Execute(mockJigsawId, redisId, userToken)).ReturnsAsync(new CustomerResponseObject()
@@ -256,6 +260,7 @@ namespace SingleViewApi.Tests.V1.UseCase
             result.Customer.PersonTypes.Should().BeEquivalentTo(peronsApiCustomer.PersonTypes);
             result.Customer.CouncilTaxAccount.Should().BeEquivalentTo(mockCouncilTaxAccount);
             result.Customer.HousingBenefitsAccount.Should().BeEquivalentTo(mockHousingBenefitsAccount);
+            result.Customer.CautionaryAlerts.Should().Equals(fakeCautionaryAlerts.Count + fakeJigsawCautionaryAlerts.Count);
         }
 
         [Test]
@@ -290,6 +295,7 @@ namespace SingleViewApi.Tests.V1.UseCase
 
             var fakeContactDetails = _fixture.Create<ContactDetails>();
             var fakeKnownAddresses = _fixture.CreateMany<KnownAddress>().ToList();
+            var fakeCautionaryAlerts = _fixture.CreateMany<CautionaryAlert>().ToList();
 
             var peronsApiCustomer = new Customer()
             {
@@ -310,7 +316,8 @@ namespace SingleViewApi.Tests.V1.UseCase
                 PlaceOfBirth = null,
                 PreferredFirstName = mockFirstName,
                 PreferredMiddleName = null,
-                PersonTypes = new List<string> { Hackney.Shared.Person.Domain.PersonType.Tenant.ToDescription() }
+                PersonTypes = new List<string> { Hackney.Shared.Person.Domain.PersonType.Tenant.ToDescription() },
+                CautionaryAlerts = fakeCautionaryAlerts
             };
 
             _mockGetPersonApiByIdUseCase.Setup(x => x.Execute(mockPersonApi, userToken)).ReturnsAsync(new CustomerResponseObject()
@@ -351,6 +358,7 @@ namespace SingleViewApi.Tests.V1.UseCase
             result.Customer.PreferredFirstName.Should().BeEquivalentTo(peronsApiCustomer.PreferredFirstName);
             result.Customer.PreferredMiddleName.Should().BeEquivalentTo(null);
             result.Customer.PersonTypes.Should().BeEquivalentTo(peronsApiCustomer.PersonTypes);
+            result.Customer.CautionaryAlerts.Should().Equals(fakeCautionaryAlerts);
 
             _mockGetJigsawCustomerByIdUseCase.Verify(x => x.Execute(mockJigsawId, redisId, userToken), Times.Never);
 

--- a/SingleViewApi/V1/Boundary/Response/MergedCustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/MergedCustomerResponseObject.cs
@@ -37,10 +37,9 @@ namespace SingleViewApi.V1.Boundary.Response
 
         public List<String> PersonTypes { get; set; }
 #nullable enable
-
         public CouncilTaxAccountInfo? CouncilTaxAccount { get; set; }
-
         public HousingBenefitsAccountInfo? HousingBenefitsAccount { get; set; }
+        public List<CautionaryAlert>? CautionaryAlerts { get; set; }
         public DateTime? DateOfBirth { get; set; }
         public string? NiNo { get; set; }
         public string? NhsNumber { get; set; }

--- a/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
@@ -90,6 +90,7 @@ namespace SingleViewApi.V1.UseCase
             var allKnownAddresses = new List<KnownAddress>();
             var allContactDetails = new List<CutomerContactDetails>();
             var allPersonType = new List<string>();
+            var allCautionaryAlerts = new List<CautionaryAlert>();
             var mergedCustomer = new MergedCustomer()
             {
                 Id = customer.Id.ToString(),
@@ -123,6 +124,11 @@ namespace SingleViewApi.V1.UseCase
                         allPersonType.AddRange(r.Customer.PersonTypes);
                     }
 
+                    if (r.Customer.CautionaryAlerts != null)
+                    {
+                        allCautionaryAlerts.AddRange(r.Customer.CautionaryAlerts);
+                    }
+
                     mergedCustomer.Title ??= r.Customer.Title;
                     mergedCustomer.PreferredTitle ??= r.Customer.PreferredTitle;
                     mergedCustomer.PreferredFirstName ??= r.Customer.PreferredFirstName;
@@ -140,6 +146,7 @@ namespace SingleViewApi.V1.UseCase
             mergedCustomer.KnownAddresses = allKnownAddresses;
             mergedCustomer.ContactDetails = allContactDetails;
             mergedCustomer.PersonTypes = allPersonType;
+            mergedCustomer.CautionaryAlerts = allCautionaryAlerts;
 
             return new MergedCustomerResponseObject()
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://trello.com/c/ebVVwsas/232-update-mergedcustomer-to-display-cautionary-alerts

## Describe this PR

### *What is the problem we're trying to solve*

- Show cautionary alerts on a merged customer. 

### *What changes have we introduced*

- Update `MergedCustomerResponseObject` to show cautionary alerts (if any).

#### _Checklist_

- [x] Added tests to cover all new production code

- [x] Checked all code for possible refactoring
