### PR TITLE
Refactor of API To Display Grouped Search Results - BREAKING CHANGE, DO NOT DEPLOY UNTIL FRONT END IS READY

### DIFF
--- a/SingleViewApi.Tests/V1/Controllers/CombinedSearchControllerTests.cs
+++ b/SingleViewApi.Tests/V1/Controllers/CombinedSearchControllerTests.cs
@@ -25,13 +25,14 @@ namespace SingleViewApi.Tests.V1.Controllers
         {
             const string firstName = "Test";
             const string lastName = "Test";
+            const string dateOfBirth = "01/01/1990";
             const string authorization = "token";
             const string redisId = "Testid";
 
 
-            _ = _classUnderTest.SearchByName(firstName, lastName, redisId, authorization);
+            _ = _classUnderTest.SearchByName(firstName, lastName, dateOfBirth, redisId, authorization);
 
-            _mockGetCombinedSearchResultsByNameUseCase.Verify(x => x.Execute(firstName, lastName, authorization, redisId), Times.Once);
+            _mockGetCombinedSearchResultsByNameUseCase.Verify(x => x.Execute(firstName, lastName, authorization, redisId, dateOfBirth), Times.Once);
         }
     }
 }

--- a/SingleViewApi.Tests/V1/Gateways/CustomerGatewayTests.cs
+++ b/SingleViewApi.Tests/V1/Gateways/CustomerGatewayTests.cs
@@ -112,7 +112,7 @@ namespace SingleViewApi.Tests.V1.Gateways
             {
                 FirstName = "Testy",
                 LastName = "McTestFace",
-                DateOfBirth = DateTime.Parse("18/08/1996").ToUniversalTime(),
+                DateOfBirth = DateTime.Parse("08/18/1996").ToUniversalTime(),
                 NiNumber = "SG01010101B"
             }.ToDatabase()).Entity;
 
@@ -145,7 +145,7 @@ namespace SingleViewApi.Tests.V1.Gateways
             {
                 FirstName = "Testy",
                 LastName = "McTestFace",
-                DateOfBirth = DateTime.Parse("18/08/1996").ToUniversalTime(),
+                DateOfBirth = DateTime.Parse("08/18/1996").ToUniversalTime(),
                 NiNumber = "SG01010101B"
             }.ToDatabase()).Entity;
 

--- a/SingleViewApi.Tests/V1/Gateways/CustomerGatewayTests.cs
+++ b/SingleViewApi.Tests/V1/Gateways/CustomerGatewayTests.cs
@@ -112,7 +112,7 @@ namespace SingleViewApi.Tests.V1.Gateways
             {
                 FirstName = "Testy",
                 LastName = "McTestFace",
-                DateOfBirth = DateTime.Parse("08/18/1996").ToUniversalTime(),
+                DateOfBirth = DateTime.Parse("18/08/1996").ToUniversalTime(),
                 NiNumber = "SG01010101B"
             }.ToDatabase()).Entity;
 
@@ -145,7 +145,7 @@ namespace SingleViewApi.Tests.V1.Gateways
             {
                 FirstName = "Testy",
                 LastName = "McTestFace",
-                DateOfBirth = DateTime.Parse("08/18/1996").ToUniversalTime(),
+                DateOfBirth = DateTime.Parse("18/08/1996").ToUniversalTime(),
                 NiNumber = "SG01010101B"
             }.ToDatabase()).Entity;
 

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -427,4 +427,28 @@ public class GetCombinedSearchResultsByNameUseCaseTests
         Assert.AreNotEqual(results[2].DataSource, results[0].DataSource);
         Assert.AreNotEqual(results[2].DataSource, results[1].DataSource);
     }
+
+    [Test]
+    public void GroupByFirstName()
+    {
+        var searchResults = new List<SearchResult>()
+        {
+            new SearchResult()
+            {
+                FirstName = "Bryan"
+            },
+            new SearchResult()
+            {
+                FirstName = "Adam"
+            },
+            new SearchResult()
+            {
+                FirstName = "Tony"
+            }
+        };
+
+        var result = _classUnderTest.GroupByFirstName(searchResults);
+
+        result[2][0].FirstName.Should().Be("Bryan");
+    }
 }

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -536,7 +536,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
         };
 
         // Act
-        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", "01/05/1989", searchResults);
+        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", "01-05-1989", searchResults);
 
         // Assert
         result.Count.Should().Be(2);

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -456,7 +456,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
             }
         };
 
-        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", "01/05/1990", searchResults);
+        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", "", searchResults);
 
         Assert.AreEqual(result[0].FirstName, "Adam");
         Assert.AreEqual(result[0].SurName, "Smith");

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -504,32 +504,34 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
     public void FilterSearchResultsWithDateOfBirthWhenGiven()
     {
         // Arrange
+        System.Globalization.CultureInfo cultureinfo = new System.Globalization.CultureInfo("en-GB");
+
         var searchResults = new List<SearchResult>()
         {
             new SearchResult()
             {
                 FirstName = "Bryan",
                 SurName = "Jones",
-                DateOfBirth = new DateTime(1990, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1990", cultureinfo)
             },
             new SearchResult()
             {
                 FirstName = "Adam",
                 SurName = "Smith",
-                DateOfBirth = new DateTime(1989, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1989", cultureinfo)
             },
             new SearchResult()
             {
                 FirstName = "Tony",
                 SurName = "Brown",
-                DateOfBirth = new DateTime(1988, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1988", cultureinfo)
             },
             new SearchResult()
             {
                 FirstName = "Adam",
                 SurName = "Smith",
                 MiddleName = "John",
-                DateOfBirth = new DateTime(1989, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1989", cultureinfo)
             },
         };
 
@@ -545,32 +547,34 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
     public void FilterSearchResultsWithOnlyNameWhenDateOfBirthNotGiven()
     {
         // Arrange
+        System.Globalization.CultureInfo cultureinfo = new System.Globalization.CultureInfo("en-GB");
+
         var searchResults = new List<SearchResult>()
         {
             new SearchResult()
             {
                 FirstName = "Bryan",
                 SurName = "Jones",
-                DateOfBirth = new DateTime(1990, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1990", cultureinfo)
             },
             new SearchResult()
             {
                 FirstName = "Adam",
                 SurName = "Smith",
-                DateOfBirth = new DateTime(1989, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1989", cultureinfo)
             },
             new SearchResult()
             {
                 FirstName = "Tony",
                 SurName = "Brown",
-                DateOfBirth = new DateTime(1988, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1988", cultureinfo)
             },
             new SearchResult()
             {
                 FirstName = "Adam",
                 SurName = "Smith",
                 MiddleName = "John",
-                DateOfBirth = new DateTime(1989, 5, 1)
+                DateOfBirth = DateTime.Parse("01/05/1989", cultureinfo)
             }
         };
 

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -575,7 +575,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
         };
 
         // Act
-        var result = _classUnderTest.GroupByRelevance("Tony", "Brown","", searchResults);
+        var result = _classUnderTest.GroupByRelevance("Tony", "Brown", "", searchResults);
 
         // Assert
         result.Count.Should().Be(1);

--- a/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCombinedSearchResultsByNameUseCaseTests.cs
@@ -48,6 +48,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
     {
         var firstName = _fixture.Create<string>();
         var lastName = _fixture.Create<string>();
+        var dateOfBirth = _fixture.Create<string>();
         var searchTerm = $"{firstName}+{lastName}";
         var redisId = _fixture.Create<string>();
         var userToken = _fixture.Create<string>();
@@ -129,7 +130,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
             });
 
 
-        var results = _classUnderTest.Execute(firstName, lastName, userToken, redisId).Result;
+        var results = _classUnderTest.Execute(firstName, lastName, userToken, redisId, dateOfBirth).Result;
 
         results.SystemIds.Should().BeEquivalentTo(expectedSystemIds);
 
@@ -140,6 +141,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
     {
         var firstName = _fixture.Create<string>();
         var lastName = _fixture.Create<string>();
+        var dateOfBirth = _fixture.Create<string>();
         var redisId = _fixture.Create<string>();
         var userToken = _fixture.Create<string>();
         var jigsawResults = _fixture.Create<SearchResponse>();
@@ -236,7 +238,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
                 x.Execute(firstName, lastName, userToken))
             .ReturnsAsync(housingBenefitsResponseObject);
 
-        var results = _classUnderTest.Execute(firstName, lastName, userToken, redisId).Result;
+        var results = _classUnderTest.Execute(firstName, lastName, userToken, redisId, dateOfBirth).Result;
 
         results.Should().BeEquivalentTo(expectedSearchResults);
     }
@@ -246,6 +248,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
     {
         var firstName = _fixture.Create<string>();
         var lastName = _fixture.Create<string>();
+        var dateOfBirth = _fixture.Create<string>();
         var userToken = _fixture.Create<string>();
         var housingResults = _fixture.Create<SearchResponse>();
         var singleViewResults = _fixture.Create<SearchResponse>();
@@ -326,7 +329,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
                 x.Execute(firstName, lastName, userToken))
             .ReturnsAsync(housingBenefitsResponseObject);
 
-        var results = _classUnderTest.Execute(firstName, lastName, userToken, null).Result;
+        var results = _classUnderTest.Execute(firstName, lastName, userToken, null, dateOfBirth).Result;
 
         results.Should().BeEquivalentTo(expectedSearchResults);
     }
@@ -453,7 +456,7 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
             }
         };
 
-        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", searchResults);
+        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", "01/05/1990", searchResults);
 
         Assert.AreEqual(result[0].FirstName, "Adam");
         Assert.AreEqual(result[0].SurName, "Smith");
@@ -495,5 +498,86 @@ public class GetCombinedSearchResultsByNameUseCaseTests : LogCallAspectFixture
         // Assert
         result.Count.Should().Be(1);
         result[0].Id.Should().Be("111");
+    }
+
+    [Test]
+    public void FilterSearchResultsWithDateOfBirthWhenGiven()
+    {
+        // Arrange
+        var searchResults = new List<SearchResult>()
+        {
+            new SearchResult()
+            {
+                FirstName = "Bryan",
+                SurName = "Jones",
+                DateOfBirth = new DateTime(1990, 5, 1)
+            },
+            new SearchResult()
+            {
+                FirstName = "Adam",
+                SurName = "Smith",
+                DateOfBirth = new DateTime(1989, 5, 1)
+            },
+            new SearchResult()
+            {
+                FirstName = "Tony",
+                SurName = "Brown",
+                DateOfBirth = new DateTime(1988, 5, 1)
+            },
+            new SearchResult()
+            {
+                FirstName = "Adam",
+                SurName = "Smith",
+                MiddleName = "John",
+                DateOfBirth = new DateTime(1989, 5, 1)
+            },
+        };
+
+        // Act
+        var result = _classUnderTest.GroupByRelevance("Adam", "Smith", "01/05/1989", searchResults);
+
+        // Assert
+        result.Count.Should().Be(2);
+        result[0].DateOfBirth.Should().Be(new DateTime(1989, 5, 1));
+    }
+
+    [Test]
+    public void FilterSearchResultsWithOnlyNameWhenDateOfBirthNotGiven()
+    {
+        // Arrange
+        var searchResults = new List<SearchResult>()
+        {
+            new SearchResult()
+            {
+                FirstName = "Bryan",
+                SurName = "Jones",
+                DateOfBirth = new DateTime(1990, 5, 1)
+            },
+            new SearchResult()
+            {
+                FirstName = "Adam",
+                SurName = "Smith",
+                DateOfBirth = new DateTime(1989, 5, 1)
+            },
+            new SearchResult()
+            {
+                FirstName = "Tony",
+                SurName = "Brown",
+                DateOfBirth = new DateTime(1988, 5, 1)
+            },
+            new SearchResult()
+            {
+                FirstName = "Adam",
+                SurName = "Smith",
+                MiddleName = "John",
+                DateOfBirth = new DateTime(1989, 5, 1)
+            }
+        };
+
+        // Act
+        var result = _classUnderTest.GroupByRelevance("Tony", "Brown","", searchResults);
+
+        // Assert
+        result.Count.Should().Be(1);
     }
 }

--- a/SingleViewApi.Tests/V1/UseCase/GetCouncilTaxAccountsByCustomerNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCouncilTaxAccountsByCustomerNameUseCaseTests.cs
@@ -78,10 +78,10 @@ public class GetCouncilTaxAccountsByCustomerNameUseCaseTests : LogCallAspectFixt
         var results = _classUnderTest.Execute(firstName, lastName, userToken).Result;
 
         results.SystemIds[^1].SystemName.Should().BeEquivalentTo(stubbedDataSource.Name);
-        results.SearchResponse.SearchResults[0].FirstName.Should().BeEquivalentTo(stubbedEntity.Customers[0].FirstName);
-        results.SearchResponse.SearchResults[0].SurName.Should().BeEquivalentTo(stubbedEntity.Customers[0].LastName);
-        results.SearchResponse.SearchResults[0].DateOfBirth.Should().Be(stubbedEntity.Customers[0].DateOfBirth);
-        results.SearchResponse.SearchResults[0].DataSource.Should().BeEquivalentTo(stubbedDataSource.Name);
+        results.SearchResponse.UngroupedResults[0].FirstName.Should().BeEquivalentTo(stubbedEntity.Customers[0].FirstName);
+        results.SearchResponse.UngroupedResults[0].SurName.Should().BeEquivalentTo(stubbedEntity.Customers[0].LastName);
+        results.SearchResponse.UngroupedResults[0].DateOfBirth.Should().Be(stubbedEntity.Customers[0].DateOfBirth);
+        results.SearchResponse.UngroupedResults[0].DataSource.Should().BeEquivalentTo(stubbedDataSource.Name);
 
     }
 

--- a/SingleViewApi.Tests/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCaseTests.cs
@@ -60,6 +60,6 @@ public class GetHousingBenefitsAccountsByCustomerNameUseCaseTests : LogCallAspec
 
         var results = _classUnderTest.Execute(firstName, lastName, userToken).Result;
 
-        results.SearchResponse.SearchResults[^1].Should().Equals(stubEntity);
+        results.SearchResponse.UngroupedResults[^1].Should().Equals(stubEntity);
     }
 }

--- a/SingleViewApi.Tests/V1/UseCase/GetJigsawCustomersUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetJigsawCustomersUseCaseTests.cs
@@ -70,9 +70,9 @@ public class GetJigsawCustomersUseCaseTests
 
         results.SystemIds[^1].SystemName.Should().BeEquivalentTo(stubbedDataSource.Name);
         results.SystemIds[^1].Id.Should().BeEquivalentTo(searchText);
-        results.SearchResponse.SearchResults[0].FirstName.Should().BeEquivalentTo(stubbedEntity[0].FirstName);
-        results.SearchResponse.SearchResults[0].SurName.Should().BeEquivalentTo(stubbedEntity[0].LastName);
-        results.SearchResponse.SearchResults[0].DateOfBirth.Should().Be(stubbedEntity[0].DoB);
-        results.SearchResponse.SearchResults[0].DataSource.Should().BeEquivalentTo(stubbedDataSource.Name);
+        results.SearchResponse.UngroupedResults[0].FirstName.Should().BeEquivalentTo(stubbedEntity[0].FirstName);
+        results.SearchResponse.UngroupedResults[0].SurName.Should().BeEquivalentTo(stubbedEntity[0].LastName);
+        results.SearchResponse.UngroupedResults[0].DateOfBirth.Should().Be(stubbedEntity[0].DoB);
+        results.SearchResponse.UngroupedResults[0].DataSource.Should().BeEquivalentTo(stubbedDataSource.Name);
     }
 }

--- a/SingleViewApi.Tests/V1/UseCase/GetSearchResultsByNameUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetSearchResultsByNameUseCaseTests.cs
@@ -76,17 +76,17 @@ namespace SingleViewApi.Tests.V1.UseCase
             results.SystemIds[^1].Id.Should().BeEquivalentTo(searchText);
 
             results.SearchResponse.Total.Should().Be(stubbedEntity.Total);
-            results.SearchResponse.SearchResults[0].FirstName.Should()
+            results.SearchResponse.UngroupedResults[0].FirstName.Should()
                 .BeEquivalentTo(stubbedEntity.Results.Persons[0].FirstName);
-            results.SearchResponse.SearchResults[0].SurName.Should()
+            results.SearchResponse.UngroupedResults[0].SurName.Should()
                 .BeEquivalentTo(stubbedEntity.Results.Persons[0].Surname);
-            results.SearchResponse.SearchResults[0].PersonTypes[0].Should()
+            results.SearchResponse.UngroupedResults[0].PersonTypes[0].Should()
                 .BeEquivalentTo(stubbedEntity.Results.Persons[0].PersonTypes.ToList()[0]);
-            results.SearchResponse.SearchResults[0].DateOfBirth.Should()
+            results.SearchResponse.UngroupedResults[0].DateOfBirth.Should()
                 .Be(stubbedEntity.Results.Persons[0].DateOfBirth);
-            results.SearchResponse.SearchResults[0].KnownAddresses[0].FullAddress.Should()
+            results.SearchResponse.UngroupedResults[0].KnownAddresses[0].FullAddress.Should()
                 .BeEquivalentTo(stubbedEntity.Results.Persons[0].Tenures.ToList()[0].AssetFullAddress);
-            results.SearchResponse.SearchResults[0].DataSource.Should().BeEquivalentTo(stubbedDataSource.Name);
+            results.SearchResponse.UngroupedResults[0].DataSource.Should().BeEquivalentTo(stubbedDataSource.Name);
         }
     }
 }

--- a/SingleViewApi.Tests/V1/UseCase/SearchSingleViewUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/SearchSingleViewUseCaseTests.cs
@@ -59,13 +59,13 @@ namespace SingleViewApi.Tests.V1.UseCase
             results.SystemIds[^1].Id.Should().BeEquivalentTo($"{firstName} {lastName}");
 
             results.SearchResponse.Total.Should().Be(1);
-            results.SearchResponse.SearchResults[0].FirstName.Should()
+            results.SearchResponse.UngroupedResults[0].FirstName.Should()
                 .BeEquivalentTo(stubbedEntity.FirstName);
-            results.SearchResponse.SearchResults[0].SurName.Should()
+            results.SearchResponse.UngroupedResults[0].SurName.Should()
                 .BeEquivalentTo(stubbedEntity.LastName);
-            results.SearchResponse.SearchResults[0].DateOfBirth.Should()
+            results.SearchResponse.UngroupedResults[0].DateOfBirth.Should()
                 .Be(stubbedEntity.DateOfBirth);
-            results.SearchResponse.SearchResults[0].DataSource.Should().BeEquivalentTo("single-view");
+            results.SearchResponse.UngroupedResults[0].DataSource.Should().BeEquivalentTo("single-view");
         }
     }
 }

--- a/SingleViewApi/V1/Boundary/Response/SearchResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/SearchResponseObject.cs
@@ -21,8 +21,8 @@ namespace SingleViewApi.V1.Boundary.Response
     public class SearchResponse
 
     {
-        public List<SearchResult> UngroupedResults { get; set; }
         public List<SearchResult> GroupedResults { get; set; }
+        public List<SearchResult> UngroupedResults { get; set; }
         public int Total { get; set; }
     }
 

--- a/SingleViewApi/V1/Boundary/Response/SearchResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/SearchResponseObject.cs
@@ -21,7 +21,8 @@ namespace SingleViewApi.V1.Boundary.Response
     public class SearchResponse
 
     {
-        public List<SearchResult> SearchResults { get; set; }
+        public List<SearchResult> UngroupedResults { get; set; }
+        public List<SearchResult> GroupedResults { get; set; }
         public int Total { get; set; }
     }
 

--- a/SingleViewApi/V1/Controllers/CombinedSearchController.cs
+++ b/SingleViewApi/V1/Controllers/CombinedSearchController.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SingleViewApi.V1.Boundary.Response;
@@ -27,9 +28,9 @@ namespace SingleViewApi.V1.Controllers
         [ProducesResponseType(typeof(SearchResponseObject), StatusCodes.Status200OK)]
 
         [HttpGet]
-        public IActionResult SearchByName([FromQuery] string firstName, string lastName, string redisId, [FromHeader] string authorization)
+        public IActionResult SearchByName([FromQuery] string firstName, string lastName, [Optional] string dateOfBirth, string redisId, [FromHeader] string authorization)
         {
-            return Ok(_getCombinedSearchResultsByNameUseCase.Execute(firstName, lastName, authorization, redisId).Result);
+            return Ok(_getCombinedSearchResultsByNameUseCase.Execute(firstName, lastName, authorization, redisId, dateOfBirth).Result);
         }
     }
 }

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -142,7 +142,7 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
 
         if (!string.IsNullOrEmpty(dateOfBirth))
         {
-            return groupedByName.Where(s => s.DateOfBirth?.ToString("dd/MM/yyyy") == dateOfBirth).ToList();
+            return groupedByName.Where(s => s.DateOfBirth?.ToString("dd-MM-yyyy") == dateOfBirth).ToList();
         }
 
         return groupedByName;

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -130,6 +130,17 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
             .ToList();
     }
 
+    [LogCall]
+    public List<List<SearchResult>> GroupByFirstName(List<SearchResult> searchResults)
+    {
+        var result =  searchResults
+                                    .GroupBy(x => x.FirstName)
+                                    .Select(g => g.ToList())
+                                    .ToList();
+
+        return result;
+    }
+
     private string Normalise(string value, int len = 0)
     {
         value = value.Replace(" ", "");

--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -29,7 +29,7 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
     }
 
     [LogCall]
-    public async Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken, string redisId)
+    public async Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken, string redisId, string dateOfBirth)
     {
         var singleViewResults = _searchSingleViewUseCase.Execute(firstName, lastName);
         var housingResults = await _getSearchResultsByNameUseCase.Execute(firstName, lastName, userToken);
@@ -77,7 +77,7 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
         var systemIds = singleViewResults?.SystemIds?.Concat(housingResults?.SystemIds)
             .Concat(councilTaxResults?.SystemIds).Concat(housingBenefitsResults?.SystemIds).ToList();
 
-        var groupedResults = GroupByRelevance(firstName, lastName, sortedResults);
+        var groupedResults = GroupByRelevance(firstName, lastName, dateOfBirth, sortedResults);
 
         var ungroupedResults = RemoveDuplicates(groupedResults, sortedResults);
 
@@ -136,9 +136,16 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
     }
 
     [LogCall]
-    public List<SearchResult> GroupByRelevance(string firstName, string lastName, List<SearchResult> searchResults)
+    public List<SearchResult> GroupByRelevance(string firstName, string lastName, string dateOfBirth, List<SearchResult> searchResults)
     {
-        return searchResults.Where(s => s.FirstName == firstName && s.SurName == lastName).ToList();
+        var groupedByName = searchResults.Where(s => s.FirstName == firstName && s.SurName == lastName).ToList();
+
+        if (!string.IsNullOrEmpty(dateOfBirth))
+        {
+            return groupedByName.Where(s => s.DateOfBirth?.ToString("dd/MM/yyyy") == dateOfBirth).ToList();
+        }
+
+        return groupedByName;
     }
 
     [LogCall]

--- a/SingleViewApi/V1/UseCase/GetCouncilTaxAccountsByCustomerNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCouncilTaxAccountsByCustomerNameUseCase.cs
@@ -71,7 +71,7 @@ public class GetCouncilTaxAccountsByCustomerNameUseCase : IGetCouncilTaxAccounts
 
         response.SearchResponse = new SearchResponse()
         {
-            SearchResults = searchResults,
+            UngroupedResults = searchResults,
             Total = searchResults.Count
         };
 

--- a/SingleViewApi/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetHousingBenefitsAccountsByCustomerNameUseCase.cs
@@ -62,7 +62,7 @@ public class GetHousingBenefitsAccountsByCustomerNameUseCase : IGetHousingBenefi
         }
         response.SearchResponse = new SearchResponse()
         {
-            SearchResults = searchResults,
+            UngroupedResults = searchResults,
             Total = searchResults.Count
         };
         return response;

--- a/SingleViewApi/V1/UseCase/GetJigsawCustomersUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetJigsawCustomersUseCase.cs
@@ -82,7 +82,7 @@ namespace SingleViewApi.V1.UseCase
 
             response.SearchResponse = new SearchResponse()
             {
-                SearchResults = personResults,
+                UngroupedResults = personResults,
                 Total = personResults.Count
             };
 

--- a/SingleViewApi/V1/UseCase/GetSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetSearchResultsByNameUseCase.cs
@@ -82,7 +82,7 @@ namespace SingleViewApi.V1.UseCase
                 response.SearchResponse = new SearchResponse()
                 {
 
-                    SearchResults = personResults,
+                    UngroupedResults = personResults,
                     Total = searchResults.Total
                 };
 

--- a/SingleViewApi/V1/UseCase/Interfaces/IGetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/Interfaces/IGetCombinedSearchResultsByNameUseCase.cs
@@ -5,5 +5,5 @@ namespace SingleViewApi.V1.UseCase.Interfaces;
 
 public interface IGetCombinedSearchResultsByNameUseCase
 {
-    Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken, string redisId);
+    Task<SearchResponseObject> Execute(string firstName, string lastName, string userToken, string redisId, string dateOfBirth = "");
 }

--- a/SingleViewApi/V1/UseCase/SearchSingleViewUseCase.cs
+++ b/SingleViewApi/V1/UseCase/SearchSingleViewUseCase.cs
@@ -60,7 +60,7 @@ namespace SingleViewApi.V1.UseCase
                 response.SearchResponse = new SearchResponse()
                 {
 
-                    SearchResults = personResults,
+                    UngroupedResults = personResults,
                     Total = searchResults.Count
                 };
 


### PR DESCRIPTION
GET `/api/v1/search?firstName={firstName}&lastName={lastName}&dateOfBirth={dd/mm/yyyy}`

Returns a search response containing an array of matching 'groupedResults' matching the name query and another array of 'ungroupedResults'.

`{
    "searchResponse": {
        "groupedResults": [
            {
                "id": "044be9c3-5c2f-42d6-beb0-05cd18271bbc",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "37b39dbb-a657-48cc-9dc7-598e8b682d98",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "fb91b986-d0c8-44a0-9857-ead23e397339",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "06600fe0-296a-4aec-99cf-f5b875c3a31d",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "b75da566-f461-40f8-a14b-6f7806ea5cd3",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "6a43e1d8-38b6-429f-aab4-d37f1a704dcb",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "a12349d2-bb94-4ada-af9d-7cef5c70a465",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "8e4dade9-b1cb-4bd0-a64c-cf830aa09887",
                "dataSource": "single-view",
                "firstName": "Test",
                "surName": "User",
                "title": null,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1980-02-01T00:00:00",
                "niNumber": null,
                "personTypes": null,
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": null
            },
            {
                "id": "e749f036-3183-49cb-8504-59b76c1a8f88",
                "dataSource": "PersonAPI",
                "firstName": "Test",
                "surName": "User",
                "title": 4,
                "middleName": null,
                "preferredFirstName": "",
                "preferredSurname": "",
                "dateOfBirth": "1980-02-01T00:00:00Z",
                "niNumber": null,
                "personTypes": [
                    1
                ],
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": [
                    {
                        "fullAddress": "31 Pellerin Road N16 8AY",
                        "id": "a26bf5da-2869-8180-6294-906aec451c7a",
                        "currentAddress": false,
                        "startDate": "1996-06-10T00:00:00Z",
                        "endDate": "1999-07-22T00:00:00Z"
                    }
                ]
            }
        ],
        "ungroupedResults": [
            {
                "id": "c36ec7a3-8c64-48e8-978b-2a00568b192c",
                "dataSource": "PersonAPI",
                "firstName": "test",
                "surName": "Testagain",
                "title": 4,
                "middleName": null,
                "preferredFirstName": "Test",
                "preferredSurname": "Testagain",
                "dateOfBirth": "1999-01-16T00:00:00Z",
                "niNumber": null,
                "personTypes": [],
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": [
                    {
                        "fullAddress": "5 Marlowe House  Milton Gardens Estate N16 8TW",
                        "id": "67bb8b7d-db11-ef67-5b10-8072c84bb7b5",
                        "currentAddress": true,
                        "startDate": "1986-01-13T00:00:00",
                        "endDate": "1900-01-01T00:00:00"
                    }
                ]
            },
            {
                "id": "58597f46-bab7-45e5-a525-a17999916b71",
                "dataSource": "PersonAPI",
                "firstName": "test",
                "surName": "test",
                "title": 3,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1999-01-01T00:00:00Z",
                "niNumber": null,
                "personTypes": [
                    1,
                    0
                ],
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": [
                    {
                        "fullAddress": "62 Dove Row E2 8RJ",
                        "id": "c48fd0c1-4ac7-2efa-abf4-c437473c8ab8",
                        "currentAddress": true,
                        "startDate": "2006-12-14T00:00:00Z",
                        "endDate": "1900-01-01T00:00:00Z"
                    },
                    {
                        "fullAddress": "Gge 3 Narford Road Hackney London E5 8RD",
                        "id": "46bc6010-7f51-49e2-842f-04d457eda29c",
                        "currentAddress": true,
                        "startDate": "1999-09-09T00:00:00Z",
                        "endDate": null
                    }
                ]
            },
            {
                "id": "00755752-60fb-4366-ae3a-880bc71545f7",
                "dataSource": "PersonAPI",
                "firstName": "Test",
                "surName": "Mc Tester Face",
                "title": 3,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1970-06-09T00:00:00Z",
                "niNumber": null,
                "personTypes": [
                    1
                ],
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": [
                    {
                        "fullAddress": "32 Broadway House  Jackman Street E8 4QY",
                        "id": "a6311713-6745-b291-9207-211ecc320c04",
                        "currentAddress": true,
                        "startDate": "2015-07-13T00:00:00Z",
                        "endDate": null
                    },
                    {
                        "fullAddress": "Gge 3 Narford Road Hackney London E5 8RD",
                        "id": "46bc6010-7f51-49e2-842f-04d457eda29c",
                        "currentAddress": true,
                        "startDate": "1999-09-09T00:00:00Z",
                        "endDate": null
                    }
                ]
            },
            {
                "id": "8b2faa61-0257-4b42-b3a3-8f5cfd7b0459",
                "dataSource": "PersonAPI",
                "firstName": "Test",
                "surName": "Mc Tester Face",
                "title": 3,
                "middleName": null,
                "preferredFirstName": null,
                "preferredSurname": null,
                "dateOfBirth": "1970-06-09T00:00:00Z",
                "niNumber": null,
                "personTypes": [
                    1
                ],
                "isPersonCautionaryAlert": false,
                "isTenureCautionaryAlert": false,
                "knownAddresses": [
                    {
                        "fullAddress": "32 Broadway House  Jackman Street E8 4QY",
                        "id": "a6311713-6745-b291-9207-211ecc320c04",
                        "currentAddress": true,
                        "startDate": "2015-07-13T00:00:00Z",
                        "endDate": null
                    },
                    {
                        "fullAddress": "Gge 3 Narford Road Hackney London E5 8RD",
                        "id": "46bc6010-7f51-49e2-842f-04d457eda29c",
                        "currentAddress": true,
                        "startDate": "1999-09-09T00:00:00Z",
                        "endDate": null
                    }
                ]
            },            
        ],
        "total": 1019
    },
    "systemIds": [
        {
            "systemName": "single-view",
            "id": "Test User",
            "error": null
        },
        {
            "systemName": "PersonAPI",
            "id": "Test+User",
            "error": null
        },
        {
            "systemName": "Academy-CouncilTax",
            "id": "Test+User",
            "error": "No Results Found"
        },
        {
            "systemName": "Academy-Benefits",
            "id": "Test+User",
            "error": "Not found"
        }
    ]
}`