### PR TITLE
Display missing info from jigsaw

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
@@ -64,6 +64,11 @@ namespace SingleViewApi.Tests.V1.UseCase
             var mockHousingBenefitsName = "AcademyHousingBenefits";
             var mockCouncilTaxAccount = _fixture.Create<CouncilTaxAccountInfo>();
             var mockDateOfBirth = _fixture.Create<DateTime>();
+            var mockPregnancyDueDate = "2000-12-01T00:00:00Z";
+            var mockAccommodationTypeId = _fixture.Create<string>();
+            var mockHousingCircumstanceId = _fixture.Create<string>();
+            var mockSupportWorker = "Adam Smith";
+            var mockGender = "Male";
 
             _mockCustomerGateway.Setup(x => x.Find(id)).Returns(new SavedCustomer()
             {
@@ -157,7 +162,13 @@ namespace SingleViewApi.Tests.V1.UseCase
                 PreferredFirstName = null,
                 PreferredMiddleName = null,
                 PersonTypes = null,
-                CautionaryAlerts = fakeCautionaryAlerts
+                CautionaryAlerts = fakeCautionaryAlerts,
+                PregnancyDueDate = mockPregnancyDueDate,
+                AccommodationTypeId = mockAccommodationTypeId,
+                HousingCircumstanceId = mockHousingCircumstanceId,
+                IsSettled = true,
+                SupportWorker = mockSupportWorker,
+                Gender = mockGender
             };
 
             _mockGetJigsawCustomerByIdUseCase.Setup(x => x.Execute(mockJigsawId, redisId, userToken)).ReturnsAsync(new CustomerResponseObject()
@@ -269,6 +280,12 @@ namespace SingleViewApi.Tests.V1.UseCase
 
             result.Customer.DateOfBirth.Should().Be(mockDateOfBirth);
             result.Customer.DateOfDeath.Should().BeNull();
+            result.Customer.PregnancyDueDate.Should().Be(mockPregnancyDueDate);
+            result.Customer.AccommodationTypeId.Should().Be(mockAccommodationTypeId);
+            result.Customer.HousingCircumstanceId.Should().Be(mockHousingCircumstanceId);
+            result.Customer.IsSettled.Should().BeTrue();
+            result.Customer.SupportWorker.Should().Be(mockSupportWorker);
+            result.Customer.Gender.Should().Be(mockGender);
             result.Customer.IsAMinor.Should().Be(peronsApiCustomer.IsAMinor);
             result.Customer.KnownAddresses.Count.Should().Be(fakeKnownAddresses.Count + fakeJigsawKnownAddresses.Count);
             result.Customer.NhsNumber.Should().BeEquivalentTo(jigsawApiCustomer.NhsNumber);

--- a/SingleViewApi.Tests/V1/UseCase/GetJigsawCustomerByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetJigsawCustomerByIdUseCaseTests.cs
@@ -56,6 +56,11 @@ public class GetJigsawCustomerByIdUseCaseTest
         const string stubbedHomePhoneNumber = "020 123 1234";
         const string stubbedMobilePhoneNumber = "070 123 1234";
         const string stubbedWorkPhoneNumber = "070 321 4321";
+        const string stubbedPregnancyDueDate = "2022-10-01T00:00:00Z";
+        const string stubbedAccommodationTypeId = "111";
+        const string stubbedHousingCircumstanceId = "112";
+        const bool stubbedIsSettled = true;
+        const string stubbedSupportWorker = "Adam Smith";
 
         var stubbedEntity = _fixture.Create<JigsawCustomerResponseObject>();
 
@@ -68,6 +73,11 @@ public class GetJigsawCustomerByIdUseCaseTest
         stubbedEntity.PersonInfo.OkToContactOnWorkPhoneNumber = true;
         stubbedEntity.PersonInfo.WorkPhoneNumber = stubbedWorkPhoneNumber;
         stubbedEntity.PersonInfo.CorrespondenceAddressString = stubbedCorrespondenceAddress;
+        stubbedEntity.PersonInfo.PregnancyDueDate = stubbedPregnancyDueDate;
+        stubbedEntity.PersonInfo.AccommodationTypeId = stubbedAccommodationTypeId;
+        stubbedEntity.PersonInfo.HousingCircumstanceId = stubbedHousingCircumstanceId;
+        stubbedEntity.PersonInfo.IsSettled = stubbedIsSettled;
+        stubbedEntity.PersonInfo.SupportWorker = stubbedSupportWorker;
 
         var stubbedDataSource = _fixture.Create<DataSource>();
         var stubbedCustomerId = _fixture.Create<string>();
@@ -90,6 +100,12 @@ public class GetJigsawCustomerByIdUseCaseTest
         results.Customer.KnownAddresses[0].FullAddress.Should().BeEquivalentTo(stubbedEntity.PersonInfo.AddressString);
         results.Customer.KnownAddresses[0].CurrentAddress.Should().Be(true);
         results.Customer.KnownAddresses[0].DataSourceName.Should().BeEquivalentTo(stubbedDataSource.Name);
+        results.Customer.PregnancyDueDate.Should().Be(stubbedEntity.PersonInfo.PregnancyDueDate);
+        results.Customer.AccommodationTypeId.Should().Be(stubbedEntity.PersonInfo.AccommodationTypeId);
+        results.Customer.HousingCircumstanceId.Should().Be(stubbedEntity.PersonInfo.HousingCircumstanceId);
+        results.Customer.IsSettled.Should().BeTrue();
+        results.Customer.SupportWorker.Should().Be(stubbedEntity.PersonInfo.SupportWorker);
+        results.Customer.Gender.Should().Be(stubbedEntity.PersonInfo.Gender);
 
         results.Customer.AllContactDetails[0].ContactType.Should().BeEquivalentTo("Email");
         results.Customer.AllContactDetails[0].DataSourceName.Should().BeEquivalentTo(stubbedDataSource.Name);

--- a/SingleViewApi/V1/Boundary/Response/CustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/CustomerResponseObject.cs
@@ -54,7 +54,7 @@ namespace SingleViewApi.V1.Boundary.Response
 
         public string? HousingCircumstanceId { get; set; }
 
-        public bool IsSettled { get; set; }
+        public bool? IsSettled { get; set; }
 
         public string? SupportWorker { get; set; }
 

--- a/SingleViewApi/V1/Boundary/Response/CustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/CustomerResponseObject.cs
@@ -48,6 +48,18 @@ namespace SingleViewApi.V1.Boundary.Response
 
         public string? NhsNumber { get; set; }
 
+        public string? PregnancyDueDate { get; set; }
+
+        public string? AccommodationTypeId { get; set; }
+
+        public string? HousingCircumstanceId { get; set; }
+
+        public bool IsSettled { get; set; }
+
+        public string? SupportWorker { get; set; }
+
+        public string? Gender { get; set; }
+
         public DateTime? DateOfDeath { get; set; }
 
         public List<CustomerContactDetails>? AllContactDetails { get; set; }

--- a/SingleViewApi/V1/Boundary/Response/Jigsaw/JigaswCustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/Jigsaw/JigaswCustomerResponseObject.cs
@@ -57,12 +57,12 @@ public class PersonInfo
     public DateTime DateOfBirth { get; set; }
     public string NationalInsuranceNumber { get; set; }
     public string NhsNumber { get; set; }
-    public object PregnancyDueDate { get; set; }
+    public string PregnancyDueDate { get; set; }
     public string AddressString { get; set; }
     public Address Address { get; set; }
     public object MoveInDate { get; set; }
-    public object AccommodationTypeId { get; set; }
-    public object HousingCircumstanceId { get; set; }
+    public string AccommodationTypeId { get; set; }
+    public string HousingCircumstanceId { get; set; }
     public bool IsSettled { get; set; }
     public object AccommodationProvider { get; set; }
     public object CorrespondenceAddress { get; set; }
@@ -75,7 +75,7 @@ public class PersonInfo
     public bool OkToContactOnWorkPhoneNumber { get; set; }
     public string EmailAddress { get; set; }
     public bool OkToContactOnEmail { get; set; }
-    public object SupportWorker { get; set; }
+    public string SupportWorker { get; set; }
     public object SupportWorkerId { get; set; }
     public string Gender { get; set; }
     public object HouseholdMemberType { get; set; }

--- a/SingleViewApi/V1/Boundary/Response/MergedCustomerResponseObject.cs
+++ b/SingleViewApi/V1/Boundary/Response/MergedCustomerResponseObject.cs
@@ -48,6 +48,12 @@ namespace SingleViewApi.V1.Boundary.Response
         public DateTime? DateOfBirth { get; set; }
         public string? NiNo { get; set; }
         public string? NhsNumber { get; set; }
+        public string? PregnancyDueDate { get; set; }
+        public string? AccommodationTypeId { get; set; }
+        public string? HousingCircumstanceId { get; set; }
+        public bool? IsSettled { get; set; }
+        public string? SupportWorker { get; set; }
+        public string? Gender { get; set; }
         public DateTime? DateOfDeath { get; set; }
         public bool? IsAMinor { get; set; }
 #nullable disable

--- a/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
@@ -132,6 +132,12 @@ namespace SingleViewApi.V1.UseCase
                     mergedCustomer.PreferredSurname ??= r.Customer.PreferredSurname;
                     mergedCustomer.PlaceOfBirth ??= r.Customer.PlaceOfBirth;
                     mergedCustomer.NhsNumber ??= r.Customer.NhsNumber;
+                    mergedCustomer.PregnancyDueDate ??= r.Customer.PregnancyDueDate;
+                    mergedCustomer.AccommodationTypeId ??= r.Customer.AccommodationTypeId;
+                    mergedCustomer.HousingCircumstanceId ??= r.Customer.HousingCircumstanceId;
+                    mergedCustomer.IsSettled ??= r.Customer.IsSettled;
+                    mergedCustomer.SupportWorker ??= r.Customer.SupportWorker;
+                    mergedCustomer.Gender ??= r.Customer.Gender;
                     mergedCustomer.IsAMinor ??= r.Customer.IsAMinor;
                     mergedCustomer.DateOfDeath ??= r.Customer.DateOfDeath;
                     mergedCustomer.CouncilTaxAccount ??= r.Customer.CouncilTaxAccount;

--- a/SingleViewApi/V1/UseCase/GetJigsawCustomerByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetJigsawCustomerByIdUseCase.cs
@@ -65,6 +65,12 @@ public class GetJigsawCustomerByIdUseCase : IGetJigsawCustomerByIdUseCase
                 DataSource = dataSource,
                 NiNo = jigsawResponse.PersonInfo.NationalInsuranceNumber,
                 NhsNumber = jigsawResponse.PersonInfo.NhsNumber,
+                PregnancyDueDate = jigsawResponse.PersonInfo.PregnancyDueDate,
+                AccommodationTypeId = jigsawResponse.PersonInfo.AccommodationTypeId,
+                HousingCircumstanceId = jigsawResponse.PersonInfo.HousingCircumstanceId,
+                IsSettled = jigsawResponse.PersonInfo.IsSettled,
+                SupportWorker = jigsawResponse.PersonInfo.SupportWorker,
+                Gender = jigsawResponse.PersonInfo.Gender,
                 KnownAddresses = new List<KnownAddress>()
                 {
                     new KnownAddress()


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/X96j0Fwt/239-display-missing-info-from-jigsaw

## Describe this PR
### *What is the problem we're trying to solve*
- Include following missing info on API so that it can be retrieved on front end to view.
- pregnancy Due Date
- accommodation Type 
- housing Circumstances
- is Settled
- support Worker - 
- gender

### *What changes have we introduced*

- Update GetJigsawCustomerByIUseCase to map the additional information from the Jigsaw data. 

#### _Checklist_

- [x] Added tests to cover all new production code

