### PR TITLE
Fix bug - NI Number not visible on merged records

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetCustomerByIdUseCaseTests.cs
@@ -64,6 +64,7 @@ namespace SingleViewApi.Tests.V1.UseCase
             var mockHousingBenefitsName = "AcademyHousingBenefits";
             var mockCouncilTaxAccount = _fixture.Create<CouncilTaxAccountInfo>();
             var mockDateOfBirth = _fixture.Create<DateTime>();
+            var mockNiNumber = "SL203040";
             var mockPregnancyDueDate = "2000-12-01T00:00:00Z";
             var mockAccommodationTypeId = _fixture.Create<string>();
             var mockHousingCircumstanceId = _fixture.Create<string>();
@@ -155,7 +156,7 @@ namespace SingleViewApi.Tests.V1.UseCase
                 IsAMinor = false,
                 KnownAddresses = fakeJigsawKnownAddresses,
                 NhsNumber = _fixture.Create<string>(),
-                NiNo = null,
+                NiNo = mockNiNumber,
                 PreferredSurname = null,
                 PreferredTitle = null,
                 PlaceOfBirth = null,
@@ -289,7 +290,7 @@ namespace SingleViewApi.Tests.V1.UseCase
             result.Customer.IsAMinor.Should().Be(peronsApiCustomer.IsAMinor);
             result.Customer.KnownAddresses.Count.Should().Be(fakeKnownAddresses.Count + fakeJigsawKnownAddresses.Count);
             result.Customer.NhsNumber.Should().BeEquivalentTo(jigsawApiCustomer.NhsNumber);
-            result.Customer.NiNo.Should().BeNull();
+            result.Customer.NiNo.Should().Be(mockNiNumber);
             result.Customer.PreferredSurname.Should().BeEquivalentTo(peronsApiCustomer.PreferredSurname);
             result.Customer.PreferredTitle.Should().BeEquivalentTo(peronsApiCustomer.PreferredTitle);
             result.Customer.PlaceOfBirth.Should().BeEquivalentTo(peronsApiCustomer.PlaceOfBirth);

--- a/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCustomerByIdUseCase.cs
@@ -132,6 +132,7 @@ namespace SingleViewApi.V1.UseCase
                     mergedCustomer.PreferredSurname ??= r.Customer.PreferredSurname;
                     mergedCustomer.PlaceOfBirth ??= r.Customer.PlaceOfBirth;
                     mergedCustomer.NhsNumber ??= r.Customer.NhsNumber;
+                    mergedCustomer.NiNo ??= r.Customer.NiNo;
                     mergedCustomer.PregnancyDueDate ??= r.Customer.PregnancyDueDate;
                     mergedCustomer.AccommodationTypeId ??= r.Customer.AccommodationTypeId;
                     mergedCustomer.HousingCircumstanceId ??= r.Customer.HousingCircumstanceId;


### PR DESCRIPTION
## Describe this PR

### What is the problem we're trying to solve
National insurance number was not visible on the merged records. (Returned as `null` in a response object)

### What changes have we introduced
- National insurance number has been mapped from `CustomerResponseObject` to `MergedCutomer`

#### Checklist

- [x] Added tests to cover all new production code
