### PR TITLE
Remove asterisks from additional factors questions

### DIFF
--- a/SingleViewApi.Tests/V1/UseCase/GetJigsawCasesByCustomerIdUseCaseTests.cs
+++ b/SingleViewApi.Tests/V1/UseCase/GetJigsawCasesByCustomerIdUseCaseTests.cs
@@ -85,7 +85,7 @@ public class GetJigsawCasesByCustomerIdUseCaseTests : LogCallAspectFixture
                         }, new Question()
                         {
                             SelectedValue = "Paracetamol",
-                            Label = "Detail current medication and dosage for all household members"
+                            Label = "* Detail current medication and dosage for all household members"
                         }
                     }
                 }
@@ -147,7 +147,7 @@ public class GetJigsawCasesByCustomerIdUseCaseTests : LogCallAspectFixture
         result.PlacementInformation[0].DclgClassificationType.Should()
             .BeEquivalentTo(mockCustomerPlacements.Placements[0].DclgClassificationType);
         result.AdditionalFactors[0].Legend.Should().BeEquivalentTo("Overview of additional factors");
-        result.AdditionalFactors[0].Info[0].Question.Should().BeEquivalentTo("* Drug/alcohol use?");
+        result.AdditionalFactors[0].Info[0].Question.Should().BeEquivalentTo("Drug/alcohol use?");
         result.AdditionalFactors[0].Info[0].Answer.Should().BeEquivalentTo("No");
         result.AdditionalFactors[0].Info[1].Question.Should().BeEquivalentTo("Detail current medication and dosage for all household members");
         result.AdditionalFactors[0].Info[1].Answer.Should().BeEquivalentTo("Paracetamol");

--- a/SingleViewApi/V1/UseCase/GetJigsawCasesByCustomerIdUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetJigsawCasesByCustomerIdUseCase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Hackney.Core.Logging;
 using ServiceStack;
@@ -123,8 +124,8 @@ public class GetJigsawCasesByCustomerIdUseCase : IGetJigsawCasesByCustomerIdUseC
             {
                 information.Add(new Information()
                 {
-                    Question = question.Label,
-                    Answer = question.GetAnswer(question.SelectedValue)
+                    Question = RemoveAsterisk(question.Label),
+                    Answer = RemoveAsterisk(question.GetAnswer(question.SelectedValue))
                 });
             }
 
@@ -136,5 +137,10 @@ public class GetJigsawCasesByCustomerIdUseCase : IGetJigsawCasesByCustomerIdUseC
         }
 
         return processedInformation;
+    }
+
+    private static string RemoveAsterisk(string data)
+    {
+        return Regex.Replace(data, "[*]", "").Trim();
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket
[Remove asterisks from additional factors questions](https://trello.com/c/i1cc8nXi/247-asterisks-in-additional-factors-answers-from-api)

## Describe this PR

### What is the problem we're trying to solve
Currently, Additional Factors questions and answers have leading asterisks.

### What changes have we introduced
Introduced a method to remove the asterisks and leading and trailing whitespace. 

#### Checklist

- [x] Added tests to cover all new production code
