### PR TITLE
Replace base url for additional-factors and health-and-well-being data

### DIFF
--- a/SingleViewApi.Tests/V1/Gateways/JigsawGatewayTests.cs
+++ b/SingleViewApi.Tests/V1/Gateways/JigsawGatewayTests.cs
@@ -370,7 +370,7 @@ public class JigsawGatewayTests : LogCallAspectFixture
         var bearerToken = _fixture.Create<string>();
         var mockData = _fixture.Create<JigsawCaseAdditionalFactorsResponseObject>();
 
-        _mockHttp.Expect($"{_accommodationBaseUrl}/caseform?caseId={caseId}&formId=1&pageId=2")
+        _mockHttp.Expect($"{_homelessnessBaseUrl}/caseform?caseId={caseId}&formId=1&pageId=2")
             .WithHeaders("Authorization", $"Bearer {bearerToken}")
             .Respond("application/json", mockData.ToJson());
 
@@ -391,7 +391,7 @@ public class JigsawGatewayTests : LogCallAspectFixture
         var bearerToken = _fixture.Create<string>();
         var mockData = _fixture.Create<JigsawCaseAdditionalFactorsResponseObject>();
 
-        _mockHttp.Expect($"{_accommodationBaseUrl}/caseform?caseId={caseId}&formId=1&pageId=2")
+        _mockHttp.Expect($"{_homelessnessBaseUrl}/caseform?caseId={caseId}&formId=1&pageId=2")
             .WithHeaders("Authorization", $"Bearer {bearerToken}")
             .Respond("application/json", mockData.ToJson());
 

--- a/SingleViewApi/V1/Gateways/JigsawGateway.cs
+++ b/SingleViewApi/V1/Gateways/JigsawGateway.cs
@@ -283,7 +283,7 @@ namespace SingleViewApi.V1.Gateways
         [LogCall]
         public async Task<JigsawCaseAdditionalFactorsResponseObject> GetCaseAdditionalFactors(string caseId, string bearerToken)
         {
-            var requestUrl = $"{_accommodationBaseUrl}/caseform?caseId={caseId}&formId=1&pageId=2";
+            var requestUrl = $"{_homelessnessBaseUrl}/caseform?caseId={caseId}&formId=1&pageId=2";
             var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
             request.Headers.Add("Authorization", $"Bearer {bearerToken}");
@@ -317,7 +317,7 @@ namespace SingleViewApi.V1.Gateways
         [LogCall]
         public async Task<JigsawCaseAdditionalFactorsResponseObject> GetCaseHealthAndWellBeing(string caseId, string bearerToken)
         {
-            var requestUrl = $"{_accommodationBaseUrl}/caseform?caseId={caseId}&formId=2&pageId=11";
+            var requestUrl = $"{_homelessnessBaseUrl}/caseform?caseId={caseId}&formId=2&pageId=11";
             var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
             request.Headers.Add("Authorization", $"Bearer {bearerToken}");


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/9raxwnpi/266-jigsaw-case-information-failing-to-load

## Describe this PR
### What is the problem we're trying to solve
Additional factors and Health and wellbeing data for Jigsaw customers were not loading. Console threw a JSON parsing error.

### What changes have we introduced
Replaced a base url to point at the write direction to fetch data from Jigsaw. 

#### Checklist
- [x] Amended tests to cover all new production code

#### Screenshots
<img width="1015" alt="Additional factors" src="https://user-images.githubusercontent.com/31739633/183638614-ef2eed8a-21bd-425e-98ae-acb58c559ab2.png">

<img width="1015" alt="Health and wellbeing factors" src="https://user-images.githubusercontent.com/31739633/183638642-e683b43a-ecd8-4786-b021-73abd3df2b80.png">

