### PR TITLE
matching for grouping results fix

### DIFF
--- a/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
+++ b/SingleViewApi/V1/UseCase/GetCombinedSearchResultsByNameUseCase.cs
@@ -151,7 +151,7 @@ public class GetCombinedSearchResultsByNameUseCase : IGetCombinedSearchResultsBy
 
     private static bool MatchByName(string firstName, string lastName, SearchResult searchResult)
     {
-        return searchResult.FirstName.ToLower() == firstName.ToLower() && searchResult.SurName.ToLower() == lastName.ToLower();
+        return searchResult.FirstName.ToLower().Contains(firstName.ToLower()) && searchResult.SurName.ToLower().Contains(lastName.ToLower());
     }
 
     [LogCall]


### PR DESCRIPTION
https://trello.com/c/IcZw3cge/286-group-search-results-regardless-if-middle-name-is-present-or-not