### PR TITLE
Converts all dates of birth to UTC time to avoid database errors

### DIFF
--- a/SingleViewApi/V1/Gateways/CustomerGateway.cs
+++ b/SingleViewApi/V1/Gateways/CustomerGateway.cs
@@ -21,6 +21,7 @@ namespace SingleViewApi.V1.Gateways
 
         public SavedCustomer Add(string firstName, string lastName, DateTime dateOfBirth, string niNumber = null)
         {
+            dateOfBirth = dateOfBirth.ToUniversalTime();
             var entity = new SavedCustomer()
             {
                 FirstName = firstName,


### PR DESCRIPTION
Before this, some merges were failing when one of the dates of birth was in a non-UTC format.

## [Link to ticket](https://trello.com/c/uL26leGP/339-patrick-hinds-problems-with-merging-records)

Made a single change to convert the datetime passed to the SavedCustomer Add method to UTC.
