### PR TITLE
Bump redis to v7

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -61,10 +61,10 @@ resource "aws_elasticache_cluster" "redis" {
 
     cluster_id           = "single-view-development"
     engine               = "redis"
-    engine_version       = "3.2.10"
-    node_type            = "cache.m4.large"
+    engine_version       = "7.1"
+    node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
-    parameter_group_name = "default.redis3.2"
+    parameter_group_name = "default.redis7.1"
     port                 = 6379
     subnet_group_name    = aws_elasticache_subnet_group.default.name
     security_group_ids   = [aws_security_group.redis_sg.id]
@@ -104,7 +104,7 @@ module "postgres_db" {
     db_port  = 5302
     subnet_ids = data.aws_subnet_ids.all.ids
     db_engine = "postgres"
-    db_engine_version = "12.8" //DMS does not work well with v12
+    db_engine_version = "12.14" //DMS does not work well with v12
     db_instance_class = "db.t3.micro"
     db_allocated_storage = 20
     maintenance_window = "sun:10:00-sun:10:30"

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -61,7 +61,7 @@ resource "aws_elasticache_cluster" "redis" {
 
     cluster_id           = "single-view-development"
     engine               = "redis"
-    engine_version       = "7.1"
+    engine_version       = "7.0"
     node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis7.1"


### PR DESCRIPTION
Current version is failing on AWS

Reduce cache size too - seems excessively provisioned