### PR TITLE
Fix merged record creation

### DIFF
--- a/SingleViewApi/Startup.cs
+++ b/SingleViewApi/Startup.cs
@@ -57,6 +57,7 @@ namespace SingleViewApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             services
                 .AddMvc().AddNewtonsoftJson();
             services.AddApiVersioning(o =>


### PR DESCRIPTION
Was failing due to `System.InvalidCastException: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported`

The addition of `AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);` fixed this