### PR TITLE
Version should be explicitly 7.0.7

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -70,7 +70,7 @@ resource "aws_elasticache_subnet_group" "default" {
 resource "aws_elasticache_cluster" "redis" {
     cluster_id           = "single-view-development"
     engine               = "redis"
-    engine_version       = "7.0"
+    engine_version       = "7.0.7"
     node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis7"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -70,7 +70,7 @@ resource "aws_elasticache_subnet_group" "default" {
 resource "aws_elasticache_cluster" "redis" {
     cluster_id           = "single-view-production"
     engine               = "redis"
-    engine_version       = "7.0"
+    engine_version       = "7.0.7"
     node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis7"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -69,7 +69,7 @@ resource "aws_elasticache_subnet_group" "default" {
 resource "aws_elasticache_cluster" "redis" {
     cluster_id           = "single-view-staging"
     engine               = "redis"
-    engine_version       = "7.0"
+    engine_version       = "7.0.7"
     node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis7"


### PR DESCRIPTION
Terraform is re-creating 7.0.7 when version is specified as 7.0 - should not do this so fixing the version at 7.0.7