### PR TITLE
Terraform friendly pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,62 +259,63 @@ jobs:
 
 workflows:
   feature-branch-checks:
-    - check-code-formatting:
-        context: api-nuget-token-context
-    - build-and-test:
-        context: api-nuget-token-context
-        requires:
-          - check-code-formatting
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
-    - assume-role-development:
-        context: api-assume-role-corporate-development-context
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
-    - preview-terraform-development:
-        requires:
-          - assume-role-development
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
-    - assume-role-staging:
-        context: api-assume-role-corporate-staging-context
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
-    - preview-terraform-staging:
-        requires:
-          - assume-role-staging
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
-    - assume-role-production:
-        context: api-assume-role-corporate-production-context
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
-    - preview-terraform-production:
-        requires:
-          - assume-role-production
-        filters:
-          branches:
-            ignore:
-              - development
-              - master
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+      - build-and-test:
+          context: api-nuget-token-context
+          requires:
+            - check-code-formatting
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-development:
+          context: api-assume-role-corporate-development-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-terraform-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-staging:
+          context: api-assume-role-corporate-staging-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-terraform-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-production:
+          context: api-assume-role-corporate-production-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-terraform-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
 
   check-and-deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,19 @@ workflows:
           filters:
             branches:
               only: development
+      - preview-terraform-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: development
+      - permit-development-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-development
+          filters:
+            branches:
+              only: development
       - terraform-init-and-apply-to-development:
           requires:
             - migrate-database-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,21 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  preview-terraform-development:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "development"
+  preview-terraform-staging:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "staging"
+  preview-terraform-production:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "production"
   terraform-init-and-apply-to-development:
     executor: docker-terraform
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ workflows:
       - terraform-init-and-apply-to-development:
           requires:
             - migrate-database-development
+            - permit-development-terraform-release
           filters:
             branches:
               only: development
@@ -391,9 +392,23 @@ workflows:
           filters:
             branches:
               only: master
+      - preview-terraform-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - permit-staging-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-staging
+          filters:
+            branches:
+              only: master
       - terraform-init-and-apply-to-staging:
           requires:
             - migrate-database-staging
+            - permit-staging-terraform-release
           filters:
             branches:
               only: master
@@ -428,6 +443,7 @@ workflows:
       - terraform-init-and-apply-to-production:
           requires:
             - migrate-database-production
+            - 
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,69 +358,78 @@ workflows:
             branches:
               only: development
   check-and-deploy-staging-and-production:
-     jobs:
-       - build-and-test:
-           context: api-nuget-token-context
-           filters:
-             branches:
-               only: master
-       - assume-role-staging:
-           context: api-assume-role-corporate-staging-context
-           requires:
-               - build-and-test
-           filters:
+    jobs:
+      - build-and-test:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
+      - assume-role-staging:
+          context: api-assume-role-corporate-staging-context
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - migrate-database-staging:
+          context: api-nuget-token-context
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - migrate-database-staging
+          filters:
+            branches:
+              only: master
+      - deploy-to-staging:
+          context: api-nuget-token-context
+          requires:
+            - terraform-init-and-apply-to-staging
+          filters:
+            branches:
+              only: master
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
               branches:
                 only: master
-       - migrate-database-staging:
-           context: api-nuget-token-context
-           requires:
-             - assume-role-staging
-       - terraform-init-and-apply-to-staging:
-           requires:
-             - migrate-database-staging
-           filters:
-             branches:
-               only: master
-       - deploy-to-staging:
-           context: api-nuget-token-context
-           requires:
-             - terraform-init-and-apply-to-staging
-           filters:
-             branches:
-               only: master
-       - permit-production-terraform-release:
-           type: approval
-           requires:
-             - deploy-to-staging
-       - assume-role-production:
-           context: api-assume-role-corporate-production-context
-           requires:
-             - permit-production-terraform-release
-           filters:
-              branches:
-                only: master
-       - migrate-database-production:
-           context: api-nuget-token-context
-           requires:
-             - assume-role-production
-       - terraform-init-and-apply-to-production:
-           requires:
-             - migrate-database-production
-           filters:
-             branches:
-               only: master
-       - permit-production-release:
-           type: approval
-           requires:
-             - deploy-to-staging
-           filters:
-             branches:
-               only: master
-       - deploy-to-production:
-           context: api-nuget-token-context
-           requires:
-             - permit-production-release
-             - terraform-init-and-apply-to-production
-           filters:
-             branches:
-               only: master
+      - assume-role-production:
+          context: api-assume-role-corporate-production-context
+          requires:
+            - permit-production-terraform-release
+          filters:
+            branches:
+              only: master
+      - migrate-database-production:
+          context: api-nuget-token-context
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-production:
+          requires:
+            - migrate-database-production
+          filters:
+            branches:
+              only: master
+      - permit-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: master
+      - deploy-to-production:
+          context: api-nuget-token-context
+          requires:
+            - permit-production-release
+            - terraform-init-and-apply-to-production
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,8 @@ workflows:
         context: api-nuget-token-context
     - build-and-test:
         context: api-nuget-token-context
+        requires:
+          - check-code-formatting
         filters:
           branches:
             ignore:
@@ -320,6 +322,8 @@ workflows:
           context: api-nuget-token-context
       - build-and-test:
           context: api-nuget-token-context
+          requires:
+          - check-code-formatting
       - assume-role-development:
           context: api-assume-role-corporate-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ workflows:
           filters:
             branches:
               only: master
-      - permit-production-terraform-release:
+      - start-production-release:
           type: approval
           requires:
             - deploy-to-staging
@@ -429,7 +429,7 @@ workflows:
       - assume-role-production:
           context: api-assume-role-corporate-production-context
           requires:
-            - permit-production-terraform-release
+            - start-production-release
           filters:
             branches:
               only: master
@@ -440,24 +440,37 @@ workflows:
           filters:
             branches:
               only: master
-      - terraform-init-and-apply-to-production:
+      - preview-terraform-production:
           requires:
-            - migrate-database-production
-            - 
+            - assume-role-production
           filters:
             branches:
               only: master
-      - permit-production-release:
+      - permit-production-terraform-release:
           type: approval
           requires:
-            - deploy-to-staging
+            - preview-terraform-production
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-production:
+          requires:
+            - migrate-database-production
+            - permit-production-terraform-release
+          filters:
+            branches:
+              only: master
+      - permit-production-api-release:
+          type: approval
+          requires:
+            - terraform-init-and-apply-to-production
           filters:
             branches:
               only: master
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
-            - permit-production-release
+            - permit-production-api-release
             - terraform-init-and-apply-to-production
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  preview-terraform:
+    description: "Previews terraform state changes"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: get, init, and plan
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,10 +320,16 @@ workflows:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: development
       - build-and-test:
           context: api-nuget-token-context
           requires:
-          - check-code-formatting
+            - check-code-formatting
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-corporate-development-context
           requires:
@@ -335,6 +341,9 @@ workflows:
           context: api-nuget-token-context
           requires:
             - assume-role-development
+          filters:
+            branches:
+              only: development
       - terraform-init-and-apply-to-development:
           requires:
             - migrate-database-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,62 @@ jobs:
           aws-account: $AWS_ACCOUNT_PRODUCTION
 
 workflows:
+  feature-branch-checks:
+    - check-code-formatting:
+        context: api-nuget-token-context
+    - build-and-test:
+        context: api-nuget-token-context
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+    - assume-role-development:
+        context: api-assume-role-corporate-development-context
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+    - preview-terraform-development:
+        requires:
+          - assume-role-development
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+    - assume-role-staging:
+        context: api-assume-role-corporate-staging-context
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+    - preview-terraform-staging:
+        requires:
+          - assume-role-staging
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+    - assume-role-production:
+        context: api-assume-role-corporate-production-context
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+    - preview-terraform-production:
+        requires:
+          - assume-role-production
+        filters:
+          branches:
+            ignore:
+              - development
+              - master
+
   check-and-deploy-development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,12 +142,6 @@ commands:
             CONNECTION_STRING=${CONN_STR} ./../dotnet-ef-local/dotnet-ef database update
 
 jobs:
-  check-env:
-    executor: docker-dotnet
-    steps:
-      - run:
-          name: print env
-          command: echo $TEST
   check-code-formatting:
     executor: docker-dotnet
     steps:
@@ -236,8 +230,6 @@ jobs:
 workflows:
   check-and-deploy-development:
     jobs:
-      - check-env:
-          context: api-nuget-token-context
       - check-code-formatting:
           context: api-nuget-token-context
       - build-and-test:


### PR DESCRIPTION
# What:
- Added Terraform development & staging & production state preview to the CCI feature branch workflow.
- Added a Safeguard to prevent development & staging & production terraform from applying automatically.
- Added additional Terraform state previews for the `development` and `master` branch workflows.
- Add the feature branch workflow.
- Removed unneeded `check-env` step.
- Made  `development` and `staging/master` workflow steps trigger on the corresponding _( `development` and `master`)_ branches.

# Why:
- We want to know the impact of our Terraform file changes before we merge those changes to the main branch.
- We don't want to staging terraform to apply automatically because occasionally resource's state gets tweaked through the AWS Web UI console, which causes Terraform drift. If left unchanged, Terraform's automatic staging apply would undo any staging environment changes done via AWS Web UI console upon any CCI pipeline run regardless of whether it tweaked infrastructure, or added an API endpoint. We want the decision of whether to undo manual AWS resource state changes to fall on the developer that caused the pipeline to trigger.
- The additional terraform previews are to prevent the issue described in the bullet-point above. It may seem redundant that we have a preview within `feature` branch, we merge, and then a preview on `master`. However, let's not forget that within Hackney we sometimes to tend a while until we merge Pull Request, and sometimes a while until we permit the deployments. As such, with enough time, the preview logs were generated on `feature` may become stale and will no longer represent the actual Terraform state (and won't catch its drift) by the time Pull Request actually gets merged due to the possibility of those: AWS Web UI tweaks, or even Cloud Engineering team running some update scripts to the same resources, or if the base module consumed by the app's local terraform receives changes, etc.
- Branch rename was made to avoid confusion about the existence of the `development` environment. The `develop` branch is heavily out of sync, and the pipeline steps have long been [removed](https://github.com/LBHackney-IT/bonuscalc-api/commit/d9629988d2c1dcb0e4e3126395da3cdad9818596).
- Added missing branch filter for one of the prod permit steps. It doesn't change any behaviour as that step depends on other workflow steps that do have the filter, however, it's better to stay explicit  to avoid ambiguity of why that one filter is missing.

# Notes:
- The new terraform workflow within the `master` workflow expects minimal time difference between the push to the branch and between the terraform apply steps.
- This is a consequence of assume role being done before the permit step. If enough time passes between the `assume role + TF preview`, and `permit TF deployment`, then the temporary AWS credentials will expire and will prevent the TF deployment.
- While this may seem like an issue or a bug within a pipeline, **it is not!** It would be easy to add another assume role after the permit, but **do not!** This behaviour is actually a feature that prevents doing the `permit terraform deployment` based on stale `preview` _(terraform plan)_ step information! If you want get a credentials issue due to temporary credentials having expired, then **just re-run the pipeline**.
- Co-authored-by: @Miles-Alford

Self awareness notes:
 - We're aware that this pipeline has a few more permits steps than an average developer may desire, however, this can be alleviated by making terraform apply step optional for deploying an application. 