### PR TITLE
Resolve `development` terraform drift & upgrade SSL certificate

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -113,7 +113,7 @@ module "postgres_db" {
     db_port  = 5302
     subnet_ids = data.aws_subnet_ids.all.ids
     db_engine = "postgres"
-    db_engine_version = "12.14" //DMS does not work well with v12
+    db_engine_version = "12.17" //DMS does not work well with v12
     db_instance_class = "db.t3.micro"
     db_allocated_storage = 20
     maintenance_window = "sun:10:00-sun:10:30"

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -70,7 +70,7 @@ resource "aws_elasticache_subnet_group" "default" {
 resource "aws_elasticache_cluster" "redis" {
     cluster_id           = "single-view-development"
     engine               = "redis"
-    engine_version       = "7.0"
+    engine_version       = "7.0.7"
     node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis7"


### PR DESCRIPTION
### What
- This change **will trigger the SSL CA Certificate update** from `rds-ca-2019` to `rds-ca-rsa2048-g1`.
- The engine version for the redis cluster has also been updated to match what is on the AWS account.
### Why
- To resolve the drift between terraform and the resources on the AWS account.
- Also to trigger the SSL Certificate update done on the **aws-hackney-common-terraform** PR [#68](https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/68).