### PR TITLE
Upgrade the pipeline's Node.js from v16 to v20.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+            curl -sL https://deb.nodesource.com/setup_20.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI


### PR DESCRIPTION
# What:
 - Bump the pipeline's Node.js version from v16 to v20.

# Why:
 - The v16 is no longer supported.
 - Node is needed for the SLS deploy.
 - We need at least the `development` or `staging` deployments to be successful to apply the Terraform up to the `production` environment.

# Screenshots:
| Node too old error |
| --- |
| ![image](https://github.com/user-attachments/assets/1beb551d-d439-4641-a9b8-c51cec0b59ad) |