### PR TITLE
Cap serverless to v3 for licensing reasons.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Install aws alerts CLI
           command: npm i -g serverless-plugin-aws-alerts


### PR DESCRIPTION
# What:
- Capped the serverless package used for API deployment to v3.

# Why:
- The current version _(v4)_ requires a paid license to use _(read more [here](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/140))_.