### PR TITLE
Fix `production` environment TF drift & which will trigger the scheduled postgres SSL certificate upgrade.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -123,4 +123,7 @@ module "postgres_db" {
     multi_az = false //only true if production deployment
     publicly_accessible = false
     project_name = "single view"
+    additional_tags = {
+        BackupPolicy = "Prod"
+    }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -113,7 +113,7 @@ module "postgres_db" {
     db_port  = 5302
     subnet_ids = data.aws_subnet_ids.all.ids
     db_engine = "postgres"
-    db_engine_version = "12.14" //DMS does not work well with v12
+    db_engine_version = "12.17" //DMS does not work well with v12
     db_instance_class = "db.t3.micro"
     db_allocated_storage = 20
     maintenance_window = "sun:10:00-sun:10:30"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -70,7 +70,7 @@ resource "aws_elasticache_subnet_group" "default" {
 resource "aws_elasticache_cluster" "redis" {
     cluster_id           = "single-view-production"
     engine               = "redis"
-    engine_version       = "7.0"
+    engine_version       = "7.0.7"
     node_type            = "cache.t4g.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis7"


### PR DESCRIPTION
# What
- This change **will trigger the SSL CA Certificate update** from `rds-ca-2019` to `rds-ca-rsa2048-g1`.
- The engine version for the redis cluster has also been updated to match what is on the AWS account.

# Why
- To resolve the drift between terraform and the resources on the AWS account.
- Also to trigger the SSL Certificate update done on the **aws-hackney-common-terraform** PR [#68](https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/68).

# Notes:
- This change also **triggers the downscale of the redis cache**, which was introduced by #115. This downscale was done because that functionality 'is broken at the current time', and even if it wasn't broken it only has ~20 records _(meaning redis is overscaled)_.

# Screenshots:
| Terraform plan preview for the production environment |
| --- |
| ![image](https://github.com/user-attachments/assets/5d5ba63b-204f-4f5d-a9ba-fc400a31bf61) |
