### PR TITLE
Upgrade postgres version to 16.1

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -113,7 +113,7 @@ module "postgres_db" {
     db_port  = 5302
     subnet_ids = data.aws_subnet_ids.all.ids
     db_engine = "postgres"
-    db_engine_version = "12.17" //DMS does not work well with v12
+    db_engine_version = "16.1" //DMS does not work well with v12
     db_instance_class = "db.t3.micro"
     db_allocated_storage = 20
     maintenance_window = "sun:10:00-sun:10:30"
@@ -123,4 +123,6 @@ module "postgres_db" {
     multi_az = false //only true if production deployment
     publicly_accessible = false
     project_name = "single view"
+    db_allow_major_version_upgrade = "true"
+    db_parameter_group_name = "postgres16"
 }


### PR DESCRIPTION
# What
This PR upgrades the postgres version from 12.17 to 16.1 through terraform. It also attaches the new `postgres16` parameter group to the database with the correct parameter values.
# Why
Part of the ongoing work of upgrading the postgres database versions so to avoid the AWS extended support costs.