### PR TITLE
Apply postgres database upgrade to v16 on `development` environment.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -113,7 +113,7 @@ module "postgres_db" {
     db_port  = 5302
     subnet_ids = data.aws_subnet_ids.all.ids
     db_engine = "postgres"
-    db_engine_version = "12.17" //DMS does not work well with v12
+    db_engine_version = "16.1" //DMS does not work well with v12
     db_instance_class = "db.t3.micro"
     db_allocated_storage = 20
     maintenance_window = "sun:10:00-sun:10:30"
@@ -123,6 +123,8 @@ module "postgres_db" {
     multi_az = false //only true if production deployment
     publicly_accessible = false
     project_name = "single view"
+    db_allow_major_version_upgrade = "true"
+    db_parameter_group_name = "postgres16"
     additional_tags = {
         BackupPolicy = "Prod"
     }


### PR DESCRIPTION
# What:
 - Merge the PR #130 from `master` into `development`

# Why:
 - Accidentally skipped the `development` branch.
 - Need the `development` branch for deployment to the `development` environment.
