### PR TITLE
Fix `Corporate-Development` and `Corporate-Staging` Terraform drift.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -113,7 +113,7 @@ module "postgres_db" {
     db_port  = 5302
     subnet_ids = data.aws_subnet_ids.all.ids
     db_engine = "postgres"
-    db_engine_version = "16.1" //DMS does not work well with v12
+    db_engine_version = "16.3" //DMS does not work well with v12
     db_instance_class = "db.t3.micro"
     db_allocated_storage = 20
     maintenance_window = "sun:10:00-sun:10:30"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -111,7 +111,7 @@ module "postgres_db" {
     db_port                    = 5302
     subnet_ids                 = data.aws_subnet_ids.all.ids
     db_engine                  = "postgres"
-    db_engine_version          = "16.1" //DMS does not work well with v12
+    db_engine_version          = "16.3" //DMS does not work well with v12
     db_instance_class          = "db.t3.micro"
     db_allocated_storage       = 20
     maintenance_window         = "sun:10:00-sun:10:30"


### PR DESCRIPTION
# What:
 - Fix the `development` single-view database's engine minor version drift.
 - Fix the `staging` single-view database's engine minor version drift.

# Why:
 - Minor versions auto-upgrade, so the drift is inevitable.
 - The `development` and `staging` drift blocks the release of the `production` drift fix.

# Notes:
 - There's pending `production` drift from the PR #132 that didn't get applied due to the pipeline failure caused by the drift this PR aims to solve.