### PR TITLE
Upgrade CI deployment to Serverless Framework v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,11 +89,8 @@ commands:
             curl -sL https://deb.nodesource.com/setup_20.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
-          name: Install serverless CLI
-          command: npm i -g serverless@^3
-      - run:
-          name: Install aws alerts CLI
-          command: npm i -g serverless-plugin-aws-alerts
+          name: Install Serverless Framework
+          command: npm i -g serverless@^4 serverless-plugin-aws-alerts
       - run:
           name: Build lambda
           command: |
@@ -104,7 +101,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./SingleViewApi/
-            sls deploy --stage <<parameters.stage>> --conceal
+            serverless deploy --stage <<parameters.stage>> --conceal
 
   migrate-database:
     description: "Migrate database"
@@ -366,7 +363,9 @@ workflows:
             branches:
               only: development
       - deploy-to-development:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - terraform-init-and-apply-to-development
           filters:
@@ -414,7 +413,9 @@ workflows:
             branches:
               only: master
       - deploy-to-staging:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - terraform-init-and-apply-to-staging
           filters:
@@ -469,7 +470,9 @@ workflows:
             branches:
               only: master
       - deploy-to-production:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - permit-production-api-release
             - terraform-init-and-apply-to-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
   aws-cli: circleci/aws-cli@5.1.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 

--- a/SingleViewApi/build.cmd
+++ b/SingleViewApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/SingleViewApi.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/SingleViewApi.zip

--- a/SingleViewApi/build.sh
+++ b/SingleViewApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/SingleViewApi.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/SingleViewApi.zip

--- a/SingleViewApi/serverless.yml
+++ b/SingleViewApi/serverless.yml
@@ -26,8 +26,8 @@ plugins:
   - serverless-plugin-aws-alerts
 
 package:
-# TODO: Rename zipfile in build.sh and build.cmd to match this
-  artifact: ./bin/release/net6.0/SingleViewApi.zip
+  # Ensure the outputs of build.sh and build.cmd match this
+  artifact: ./bin/release/SingleViewApi.zip
 
 functions:
   SingleViewApi:


### PR DESCRIPTION
## Describe this PR

This PR bumps Serverless Framework to version 4 and introduces a CircleCI context for the newly required license key.

It also removes the .NET version from the build artifact path, to remove one step when we upgrade it.
